### PR TITLE
FB58：Dockerfileを利用する研究かどうかでワークフロー機能に必要なパッケージの設定ファイルの形式を切り替える。の対応 

### DIFF
--- a/internal/route/repo/editor.go
+++ b/internal/route/repo/editor.go
@@ -631,18 +631,18 @@ func createDmp(c context.AbstructContext, f AbstructRepoUtil, d AbstructDmpUtil)
 
 	// data binding for "Add DMP" pulldown at DMP editing page
 	// (The pulldown on the repository top page is binded in repo.renderDirectory.)
-	err := d.BidingDmpSchemaList(c, schemaUrl+"orgs")
+	err := d.BidingDmpSchemaList(c, schemaUrl+"orgs"+"?ref=feature/fb58")
 	if err != nil {
 		log.Error("%v", err)
 		return
 	}
-	err = d.FetchDmpSchema(c, schemaUrl+"json_schema/schema_dmp_"+schema)
+	err = d.FetchDmpSchema(c, schemaUrl+"json_schema/schema_dmp_"+schema+"?ref=feature/fb58")
 	if err != nil {
 		log.Error("%v", err)
 		return
 	}
 
-	srcBasic, err := f.FetchContentsOnGithub(schemaUrl + "basic")
+	srcBasic, err := f.FetchContentsOnGithub(schemaUrl + "basic" + "?ref=feature/fb58")
 	if err != nil {
 		log.Error("%v", err)
 		return

--- a/internal/route/repo/editor.go
+++ b/internal/route/repo/editor.go
@@ -631,18 +631,18 @@ func createDmp(c context.AbstructContext, f AbstructRepoUtil, d AbstructDmpUtil)
 
 	// data binding for "Add DMP" pulldown at DMP editing page
 	// (The pulldown on the repository top page is binded in repo.renderDirectory.)
-	err := d.BidingDmpSchemaList(c, schemaUrl+"orgs"+"?ref=feature/fb58")
+	err := d.BidingDmpSchemaList(c, schemaUrl+"orgs")
 	if err != nil {
 		log.Error("%v", err)
 		return
 	}
-	err = d.FetchDmpSchema(c, schemaUrl+"json_schema/schema_dmp_"+schema+"?ref=feature/fb58")
+	err = d.FetchDmpSchema(c, schemaUrl+"json_schema/schema_dmp_"+schema)
 	if err != nil {
 		log.Error("%v", err)
 		return
 	}
 
-	srcBasic, err := f.FetchContentsOnGithub(schemaUrl + "basic" + "?ref=feature/fb58")
+	srcBasic, err := f.FetchContentsOnGithub(schemaUrl + "basic")
 	if err != nil {
 		log.Error("%v", err)
 		return

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -321,24 +321,25 @@ func fetchEmviromentfile(c context.AbstructContext) {
 		path := Emviromentfilepath + Emviromentfile[i]
 		src, err := f.FetchContentsOnGithub(path)
 		if err != nil {
-			log.Error(2, "Dockerfile could not be fetched: %v", err)
+			log.Error(2, "%s could not be fetched: %v", Emviromentfile[i], err)
 		}
 
 		decodefile, err := f.DecodeBlobContent(src)
 		if err != nil {
-			log.Error(2, "Dockerfile could not be decorded: %v", err)
+			log.Error(2, "%s could not be decorded: %v", Emviromentfile[i], err)
 
-			failedGenereteMaDmp(c, "Sorry, faild gerate maDMP: fetching template failed(Dockerfile)")
+			failedGenereteMaDmp(c, "Sorry, faild gerate maDMP: fetching template failed(Emviromentfile)")
 			return
 		}
 
+		treeName := "binder/" + Emviromentfile[i]
 		message := "[GIN] fetch " + Emviromentfile[i]
 		_ = c.GetRepo().GetDbRepo().UpdateRepoFile(c.GetUser(), db.UpdateRepoFileOptions{
 			LastCommitID: c.GetRepo().GetLastCommitIdStr(),
 			OldBranch:    c.GetRepo().GetBranchName(),
 			NewBranch:    c.GetRepo().GetBranchName(),
 			OldTreeName:  "",
-			NewTreeName:  path,
+			NewTreeName:  treeName,
 			Message:      message,
 			Content:      decodefile,
 			IsNewFile:    true,

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -119,8 +119,10 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 		return
 	}
 
+	/* DMPの内容によって、DockerFileを利用しないケースがあったため、
+	　 DMPの内容を取得した後に、DockerFileを取得するように修正 */
 	// コード付帯機能の起動時間短縮のための暫定的な定義
-	fetchDockerfile(c)
+	// fetchDockerfile(c)
 
 	// ユーザが作成したDMP情報取得
 	entry, err := c.GetRepo().GetCommit().Blob("/dmp.json")
@@ -151,6 +153,7 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 	selectedField := dmp.(map[string]interface{})["field"]
 	selectedDataSize := dmp.(map[string]interface{})["dataSize"]
 	selectedDatasetStructure := dmp.(map[string]interface{})["datasetStructure"]
+	selectedUseDocker := dmp.(map[string]interface{})["useDocker"]
 	/* maDMPへ埋め込む情報を追加する際は
 	ここに追記のこと
 	e.g.
@@ -170,6 +173,7 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 			selectedField, // ここより以下は埋め込む値: DMP情報
 			selectedDataSize,
 			selectedDatasetStructure,
+			selectedUseDocker,
 			/* maDMPへ埋め込む情報を追加する際は
 			ここに追記のこと
 			e.g.
@@ -184,6 +188,14 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 		return
 	}
 
+	/* Dockerfileか、binderフォルダを取得する。 */
+	if selectedUseDocker == "YES" {
+		/* dockerファイルを取得する */
+		fetchDockerfile(c)
+	} else {
+		/* binderフォルダ配下の環境構成ファイルを取得する */
+		fetchEmviromentfile(c)
+	}
 	c.GetFlash().Success("maDMP generated!")
 	c.Redirect(c.GetRepo().GetRepoLink())
 }
@@ -293,6 +305,46 @@ func fetchDockerfile(c context.AbstructContext) {
 		Content:      decodedDockerfile,
 		IsNewFile:    true,
 	})
+}
+
+// fetchEmviromentfile is RCOS specific code.
+// This fetches the Dockerfile used when launching Binderhub.
+func fetchEmviromentfile(c context.AbstructContext) {
+	// コード付帯機能の起動時間短縮のための暫定的な定義
+	Emviromentfilepath := getTemplateUrl() + "binder/"
+
+	var f repoUtil
+
+	Emviromentfile := []string{"apt.txt", "postBuild"}
+
+	for i := 0; i < len(Emviromentfile); i++ {
+		path := Emviromentfilepath + Emviromentfile[i]
+		src, err := f.FetchContentsOnGithub(path)
+		if err != nil {
+			log.Error(2, "Dockerfile could not be fetched: %v", err)
+		}
+
+		decodefile, err := f.DecodeBlobContent(src)
+		if err != nil {
+			log.Error(2, "Dockerfile could not be decorded: %v", err)
+
+			failedGenereteMaDmp(c, "Sorry, faild gerate maDMP: fetching template failed(Dockerfile)")
+			return
+		}
+
+		message := "[GIN] fetch " + Emviromentfile[i]
+		_ = c.GetRepo().GetDbRepo().UpdateRepoFile(c.GetUser(), db.UpdateRepoFileOptions{
+			LastCommitID: c.GetRepo().GetLastCommitIdStr(),
+			OldBranch:    c.GetRepo().GetBranchName(),
+			NewBranch:    c.GetRepo().GetBranchName(),
+			OldTreeName:  "",
+			NewTreeName:  path,
+			Message:      message,
+			Content:      decodefile,
+			IsNewFile:    true,
+		})
+	}
+
 }
 
 // resolveAnnexedContent takes a buffer with the contents of a git-annex


### PR DESCRIPTION
## やったこと

FB58の対応にて、
・DMP作成時に、Dockerfileを使用しているかを選択できるようにしました。
・maDMP作成時に、Dockerfileを使用している場合はDockerfileのテンプレートを取得するように。
    Dockerfileを利用していない場合は、apt.txtとpostBuildのファイルを取得するように修正。

## やらないこと

・特になし。

## できるようになること（ユーザ目線）

・Dockerfile以外を利用した研究に対応できるようになる。
・ユーザ目線以外としては、repo2dockerのDockerfileでのコンテナ作成がBeta版であることに影響を受けなくなる。

## できなくなること（ユーザ目線）

・特になし。

## 動作確認の内容と結果

・ローカルで起動したgogsにてテストを実施し、問題ないことを確認。

## その他

・gogs側の実装が、Masterブランチを直接参照しにいく実装だったため、gogs側の実装をこのBranchを参照するようにソースを改変してテストを行った。
・該当の環境構成ファイルを用いて、コード付帯機能にてコンテナを起動できるかについては、MasterへとMergeをした後に実施予定。