### PR TITLE
未ログイン時にリポジトリ検索を行うとエラーになるバグに対応

### DIFF
--- a/internal/route/home.go
+++ b/internal/route/home.go
@@ -58,7 +58,12 @@ func ExploreRepos(c *context.Context) {
 	c.Data["PageIsExploreRepositories"] = true
 
 	// for "Metadata" link on navbar
-	c.Data["IsUserFA"] = (c.User.Type >= db.UserFA)
+	uname := c.GetCookie(conf.Security.CookieUsername)
+	if len(uname) == 0 {
+		c.Data["IsUserFA"] = 0
+	} else {
+		c.Data["IsUserFA"] = (c.User.Type >= db.UserFA)
+	}
 
 	page := c.QueryInt("page")
 	if page <= 0 {
@@ -297,7 +302,12 @@ func ExploreUsers(c *context.Context) {
 	c.Data["PageIsExploreUsers"] = true
 
 	// for "Metadata" link on navbar
-	c.Data["IsUserFA"] = (c.User.Type >= db.UserFA)
+	uname := c.GetCookie(conf.Security.CookieUsername)
+	if len(uname) == 0 {
+		c.Data["IsUserFA"] = 0
+	} else {
+		c.Data["IsUserFA"] = (c.User.Type >= db.UserFA)
+	}
 
 	RenderUserSearch(c, &UserSearchOptions{
 		Type:     db.UserIndividual,
@@ -315,7 +325,12 @@ func ExploreOrganizations(c *context.Context) {
 	c.Data["PageIsExploreOrganizations"] = true
 
 	// for "Metadata" link on navbar
-	c.Data["IsUserFA"] = (c.User.Type >= db.UserFA)
+	uname := c.GetCookie(conf.Security.CookieUsername)
+	if len(uname) == 0 {
+		c.Data["IsUserFA"] = 0
+	} else {
+		c.Data["IsUserFA"] = (c.User.Type >= db.UserFA)
+	}
 
 	RenderUserSearch(c, &UserSearchOptions{
 		Type:     db.UserOrganization,

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -1,6 +1,5 @@
 package repo
 
-// test
 import (
 	"bufio"
 	"bytes"

--- a/internal/route/search_gin.go
+++ b/internal/route/search_gin.go
@@ -147,7 +147,12 @@ func ExploreData(c *context.Context) {
 	c.Data["PageIsExploreData"] = true
 
 	// for "Metadata" link on navbar
-	c.Data["IsUserFA"] = (c.User.Type >= db.UserFA)
+	uname := c.GetCookie(conf.Security.CookieUsername)
+	if len(uname) == 0 {
+		c.Data["IsUserFA"] = 0
+	} else {
+		c.Data["IsUserFA"] = (c.User.Type >= db.UserFA)
+	}
 
 	// send query data back even if the search fails or is aborted to fill in
 	// the form on refresh
@@ -193,7 +198,12 @@ func ExploreCommits(c *context.Context) {
 	c.Data["PageIsExploreCommits"] = true
 
 	// for "Metadata" link on navbar
-	c.Data["IsUserFA"] = (c.User.Type >= db.UserFA)
+	uname := c.GetCookie(conf.Security.CookieUsername)
+	if len(uname) == 0 {
+		c.Data["IsUserFA"] = 0
+	} else {
+		c.Data["IsUserFA"] = (c.User.Type >= db.UserFA)
+	}
 
 	// send query data back even if the search fails or is aborted to fill in
 	// the form on refresh


### PR DESCRIPTION
## やったこと

未ログイン時にリポジトリ検索を行うとエラーになるバグに対応

## やらないこと

なし

## できるようになること（ユーザ目線）

未ログイン時でのリポジトリ検索

## できなくなること（ユーザ目線）

なし

## 動作確認の内容と結果

ローカル環境にて未ログイン時のエラーにならないことを確認。

## その他

なし。
