### PR TITLE
can search repositories by id with api

### DIFF
--- a/internal/db/repo.go
+++ b/internal/db/repo.go
@@ -1770,6 +1770,7 @@ func GetRepositoryCount(u *User) (int64, error) {
 }
 
 type SearchRepoOptions struct {
+	ID       int64 // GIN-fork specific
 	Keyword  string
 	OwnerID  int64
 	UserID   int64 // When set results will contain all public/private repositories user has access to
@@ -1804,6 +1805,10 @@ func SearchRepositoryByName(opts *SearchRepoOptions) (repos []*Repository, count
 	}
 	if opts.OwnerID > 0 {
 		sess.And("repo.owner_id = ?", opts.OwnerID)
+	}
+	//GIN-fork specific
+	if opts.ID > 0 {
+		sess.And("repo.id = ?", opts.ID)
 	}
 
 	// We need all fields (repo.*) in final list but only ID (repo.id) is good enough for counting.

--- a/internal/route/api/v1/repo/repo.go
+++ b/internal/route/api/v1/repo/repo.go
@@ -21,6 +21,7 @@ import (
 
 func Search(c *context.APIContext) {
 	opts := &db.SearchRepoOptions{
+		ID:       c.QueryInt64("id"),
 		Keyword:  path.Base(c.Query("q")),
 		OwnerID:  c.QueryInt64("uid"),
 		PageSize: convert.ToCorrectPageSize(c.QueryInt("limit")),


### PR DESCRIPTION
FB39の修正に必要なAPI（リポジトリIDを引数にリポジトリ情報を検索できる）を用意しました。

修正元のAPI：https://github.com/gogs/docs-api/tree/master/Repositories#search-repositories
修正内容：APIの引数にIDを追加し、その引数が与えられた場合は値に合致したものを検索するようにしました。

確認内容
ローカル環境で確認し、localhost:3000/api/v1/repos/search?id=1で検索できることを確認しました。
また、修正後も既存の変数(ユーザIDなど）で検索できることを確認しました。
以下、API実行結果のキャプチャです。
![image](https://user-images.githubusercontent.com/91708725/188403114-019c1e2e-a017-4f45-aaca-47f1e8301cd8.png)


