### PR TITLE
maDMP実行環境へのbinderリンクを、GIN-forkヘッダに移動させました。

### DIFF
--- a/custom/conf/readme/Default
+++ b/custom/conf/readme/Default
@@ -1,5 +1,3 @@
-# {Name}
-
 {Description}
 
 ## モニタリング
@@ -65,7 +63,6 @@
 
 5. ワークフロー実行環境へ遷移
 
-    「Generate maDMP」ボタンをクリックしてmaDMPを生成したら、以下のボタンをクリックしてワークフロー実行環境へ移ることができます。<br>
-    ※maDMP作成前は、ボタンをクリックしても遷移できませんのでご注意ください。
+    「Generate maDMP」ボタンをクリックしてmaDMPを生成したら、画面右上に出てくる「launch binder」ボタンをクリックしてワークフロー実行環境へ移ることができます。<br>
 
-maDMP実行環境へ遷移：[![Binder](https://binder.cs.rcos.nii.ac.jp/badge_logo.svg)](https://binder.cs.rcos.nii.ac.jp/v2/git/http%3A%2F%2Fdg02.dg.rcos.nii.ac.jp%2F{Doer}%2F{Name}.git/master?filepath=maDMP.ipynb)
+

--- a/custom/templates/repo/header_gin.tmpl
+++ b/custom/templates/repo/header_gin.tmpl
@@ -13,7 +13,7 @@
 									<div class="ui labeled button" data-tooltip="Transition to the maDMP execution environment. Please click this after 'Generate maDMP'" data-position="bottom center">
                                 	<button class="ui basic button" data-position="bottom center">
 										<a href="https://binder.cs.rcos.nii.ac.jp/v2/git/http%3A%2F%2Fdg02.dg.rcos.nii.ac.jp%2F{{.Owner.Name}}%2F{{.Repository.Name}}.git/master?filepath=maDMP.ipynb">
-											<img src="https://static.mybinder.org/badge_logo.svg">
+											<img src="https://binder.cs.rcos.nii.ac.jp/badge_logo.svg">
 										</a> 
 									</button>
                     				</div>

--- a/custom/templates/repo/header_gin.tmpl
+++ b/custom/templates/repo/header_gin.tmpl
@@ -5,12 +5,18 @@
 							<a class="ui basic button" href="/{{.Repository.Owner.Name}}/{{.Repository.Name}}/doi"><i class="octicon octicon-squirrel"></i> Request {{if $.DOI}}New{{end}} DOI</a> */}}
 						{{/* {{else if not $.DOI}} Link to registration instructions*/}}
 							<!--a class="ui basic button" data-tooltip="Your repository does not fulfill all requirements for a DOI yet. Click to get instructions." data-position="bottom center" href="/G-Node/Info/wiki/DOI"><i class="octicon octicon-squirrel"></i> How to publish</!--a -->
+						<div style="display:flex;">
 							{{if $.HasDmpJson}}
 								<a class="ui basic button" href="{{$.RepoLink}}/_edit/{{EscapePound $.BranchName}}/dmp.json" data-position="bottom center"><i class="octicon octicon-file"></i>Edit DMP JSON</a>
-
 								{{ if $.HasMaDmp }}
-									<br>
 									<a class="ui basic button" href="{{$.RepoLink}}/src/{{EscapePound $.BranchName}}/maDMP.ipynb" data-position="bottom center"><i class="octicon octicon-file"></i>View maDMP</a>
+									<div class="ui labeled button" data-tooltip="Transition to the maDMP execution environment. Please click this after 'Generate maDMP'" data-position="bottom center">
+                                	<button class="ui basic button" data-position="bottom center">
+										<a href="https://binder.cs.rcos.nii.ac.jp/v2/git/http%3A%2F%2Fdg02.dg.rcos.nii.ac.jp%2F{{.Owner.Name}}%2F{{.Repository.Name}}.git/master?filepath=maDMP.ipynb">
+											<img src="https://static.mybinder.org/badge_logo.svg">
+										</a> 
+									</button>
+                    				</div>
 								{{ else }}
 									<form method="post" name="generate_maDMP" action="{{$.RepoLink}}/madmp">
 										{{.CSRFTokenHTML}}
@@ -20,13 +26,12 @@
 							{{else}}
 								<select class="ui basic button" name="addDmp" onChange="location.href=value;">
 									<option value="" selected>Add DMP</option>
-
 									{{ range $v := $.SchemaList }}
 										<option value="{{$.RepoLink}}/_add/{{EscapePound $.BranchName}}/dmp.json/?schema={{$v}}">{{ $v }}</option>
 									{{ end }}
-
 								</select>
 							{{end}}
+						</div>
 						{{/* {{end}}  End registration button */}}
 					{{end}} {{/* Admin section */}}
 					{{if $.DOI}} {{/* Registered repo: Show DOI badge */}}

--- a/templates/repo/header_gin.tmpl
+++ b/templates/repo/header_gin.tmpl
@@ -1,16 +1,38 @@
 {{if not $.IsBareRepo}}
 	{{if or $.DOI $.IsRepositoryAdmin}} {{/* Show DOI buttons or badge */}}
 					{{if $.IsRepositoryAdmin}}
-						{{if $.IsDOIReady}} {{/* Ready to (re)register: Show button */}}
-							<a class="ui basic button" href="/{{.Repository.Owner.Name}}/{{.Repository.Name}}/doi"><i class="octicon octicon-squirrel"></i> Request {{if $.DOI}}New{{end}} DOI</a>
-						{{else if not $.DOI}} {{/*Link to registration instructions*/}}
-							<a class="ui basic button" data-tooltip="Your repository does not fulfill all requirements for a DOI yet. Click to get instructions." data-position="bottom center" href="/G-Node/Info/wiki/DOI"><i class="octicon octicon-squirrel"></i> How to publish</a>
+						{{/* {{if $.IsDOIReady}}  Ready to (re)register: Show button
+							<a class="ui basic button" href="/{{.Repository.Owner.Name}}/{{.Repository.Name}}/doi"><i class="octicon octicon-squirrel"></i> Request {{if $.DOI}}New{{end}} DOI</a> */}}
+						{{/* {{else if not $.DOI}} Link to registration instructions*/}}
+							<!--a class="ui basic button" data-tooltip="Your repository does not fulfill all requirements for a DOI yet. Click to get instructions." data-position="bottom center" href="/G-Node/Info/wiki/DOI"><i class="octicon octicon-squirrel"></i> How to publish</!--a -->
+						<div style="display:flex;">
 							{{if $.HasDmpJson}}
-								<a class="ui basic button" href="{{$.RepoLink}}/_edit/{{EscapePound $.BranchName}}/datacite.yml" data-position="bottom center"><i class="octicon octicon-file"></i>Edit DataCite file</a>
+								<a class="ui basic button" href="{{$.RepoLink}}/_edit/{{EscapePound $.BranchName}}/dmp.json" data-position="bottom center"><i class="octicon octicon-file"></i>Edit DMP JSON</a>
+								{{ if $.HasMaDmp }}
+									<a class="ui basic button" href="{{$.RepoLink}}/src/{{EscapePound $.BranchName}}/maDMP.ipynb" data-position="bottom center"><i class="octicon octicon-file"></i>View maDMP</a>
+									<div class="ui labeled button" data-tooltip="Transition to the maDMP execution environment. Please click this after 'Generate maDMP'" data-position="bottom center">
+                                	<button class="ui basic button" data-position="bottom center">
+										<a href="https://binder.cs.rcos.nii.ac.jp/v2/git/http%3A%2F%2Fdg02.dg.rcos.nii.ac.jp%2F{{.Owner.Name}}%2F{{.Repository.Name}}.git/master?filepath=maDMP.ipynb">
+											<img src="https://static.mybinder.org/badge_logo.svg">
+										</a> 
+									</button>
+                    				</div>
+								{{ else }}
+									<form method="post" name="generate_maDMP" action="{{$.RepoLink}}/madmp">
+										{{.CSRFTokenHTML}}
+										<a class="ui basic button" href= "javascript:generate_maDMP.submit()" data-position="bottom center"><i class="octicon octicon-file"></i>Generate maDMP</a>
+									</form>
+								{{ end }}
 							{{else}}
-								<a class="ui basic button" href="{{$.RepoLink}}/_add/{{EscapePound $.BranchName}}/datacite.yml" data-position="bottom center"><i class="octicon octicon-file"></i>Add DataCite file</a>
+								<select class="ui basic button" name="addDmp" onChange="location.href=value;">
+									<option value="" selected>Add DMP</option>
+									{{ range $v := $.SchemaList }}
+										<option value="{{$.RepoLink}}/_add/{{EscapePound $.BranchName}}/dmp.json/?schema={{$v}}">{{ $v }}</option>
+									{{ end }}
+								</select>
 							{{end}}
-						{{end}} {{/* End registration button */}}
+						</div>
+						{{/* {{end}}  End registration button */}}
 					{{end}} {{/* Admin section */}}
 					{{if $.DOI}} {{/* Registered repo: Show DOI badge */}}
 						<div class="ui labeled button" tabindex="0">

--- a/templates/repo/header_gin.tmpl
+++ b/templates/repo/header_gin.tmpl
@@ -1,38 +1,16 @@
 {{if not $.IsBareRepo}}
 	{{if or $.DOI $.IsRepositoryAdmin}} {{/* Show DOI buttons or badge */}}
 					{{if $.IsRepositoryAdmin}}
-						{{/* {{if $.IsDOIReady}}  Ready to (re)register: Show button
-							<a class="ui basic button" href="/{{.Repository.Owner.Name}}/{{.Repository.Name}}/doi"><i class="octicon octicon-squirrel"></i> Request {{if $.DOI}}New{{end}} DOI</a> */}}
-						{{/* {{else if not $.DOI}} Link to registration instructions*/}}
-							<!--a class="ui basic button" data-tooltip="Your repository does not fulfill all requirements for a DOI yet. Click to get instructions." data-position="bottom center" href="/G-Node/Info/wiki/DOI"><i class="octicon octicon-squirrel"></i> How to publish</!--a -->
-						<div style="display:flex;">
+						{{if $.IsDOIReady}} {{/* Ready to (re)register: Show button */}}
+							<a class="ui basic button" href="/{{.Repository.Owner.Name}}/{{.Repository.Name}}/doi"><i class="octicon octicon-squirrel"></i> Request {{if $.DOI}}New{{end}} DOI</a>
+						{{else if not $.DOI}} {{/*Link to registration instructions*/}}
+							<a class="ui basic button" data-tooltip="Your repository does not fulfill all requirements for a DOI yet. Click to get instructions." data-position="bottom center" href="/G-Node/Info/wiki/DOI"><i class="octicon octicon-squirrel"></i> How to publish</a>
 							{{if $.HasDmpJson}}
-								<a class="ui basic button" href="{{$.RepoLink}}/_edit/{{EscapePound $.BranchName}}/dmp.json" data-position="bottom center"><i class="octicon octicon-file"></i>Edit DMP JSON</a>
-								{{ if $.HasMaDmp }}
-									<a class="ui basic button" href="{{$.RepoLink}}/src/{{EscapePound $.BranchName}}/maDMP.ipynb" data-position="bottom center"><i class="octicon octicon-file"></i>View maDMP</a>
-									<div class="ui labeled button" data-tooltip="Transition to the maDMP execution environment. Please click this after 'Generate maDMP'" data-position="bottom center">
-                                	<button class="ui basic button" data-position="bottom center">
-										<a href="https://binder.cs.rcos.nii.ac.jp/v2/git/http%3A%2F%2Fdg02.dg.rcos.nii.ac.jp%2F{{.Owner.Name}}%2F{{.Repository.Name}}.git/master?filepath=maDMP.ipynb">
-											<img src="https://static.mybinder.org/badge_logo.svg">
-										</a> 
-									</button>
-                    				</div>
-								{{ else }}
-									<form method="post" name="generate_maDMP" action="{{$.RepoLink}}/madmp">
-										{{.CSRFTokenHTML}}
-										<a class="ui basic button" href= "javascript:generate_maDMP.submit()" data-position="bottom center"><i class="octicon octicon-file"></i>Generate maDMP</a>
-									</form>
-								{{ end }}
+								<a class="ui basic button" href="{{$.RepoLink}}/_edit/{{EscapePound $.BranchName}}/datacite.yml" data-position="bottom center"><i class="octicon octicon-file"></i>Edit DataCite file</a>
 							{{else}}
-								<select class="ui basic button" name="addDmp" onChange="location.href=value;">
-									<option value="" selected>Add DMP</option>
-									{{ range $v := $.SchemaList }}
-										<option value="{{$.RepoLink}}/_add/{{EscapePound $.BranchName}}/dmp.json/?schema={{$v}}">{{ $v }}</option>
-									{{ end }}
-								</select>
+								<a class="ui basic button" href="{{$.RepoLink}}/_add/{{EscapePound $.BranchName}}/datacite.yml" data-position="bottom center"><i class="octicon octicon-file"></i>Add DataCite file</a>
 							{{end}}
-						</div>
-						{{/* {{end}}  End registration button */}}
+						{{end}} {{/* End registration button */}}
 					{{end}} {{/* Admin section */}}
 					{{if $.DOI}} {{/* Registered repo: Show DOI badge */}}
 						<div class="ui labeled button" tabindex="0">


### PR DESCRIPTION
# やったこと
maDMP実行環境へのbinderリンクを、GIN-forkヘッダに移動させました。
これによって、リポジトリ名が更新された場合も、最新のリポジトリのURLがbinderリンクに埋め込まれるためリンクが切れません。
また、DMP関連のボタン配置を横並びに整理しました。以下、キャプチャです。
![image](https://user-images.githubusercontent.com/91708725/189008696-48fbb033-a57e-4e16-8593-6303b457b4c1.png)

# やらないこと
デザインはこだわっていないです。

# ユーザができること
リポジトリ名を変更しても実行環境への遷移でエラーが起きません。

# ユーザができなくなること
特にありません。

# テスト
ローカルでbinderボタンに最新のリポジトリ情報が入っていることを確認しました。
DMP関連のボタンが横並びにあることを確認しました。