### PR TITLE
Feature/fork increment

### DIFF
--- a/internal/db/repo.go
+++ b/internal/db/repo.go
@@ -2522,9 +2522,8 @@ func ForkRepository(doer, owner *User, baseRepo *Repository, name, desc string) 
 		log.Error("PrepareWebhooks [repo_id: %d]: %v", baseRepo.ID, err)
 	}
 
-	if !baseRepo.IsOwnedBy(owner.ID) { //★
+	if !baseRepo.IsOwnedBy(owner.ID) {
 		baseRepo.NumForks = baseRepo.NumForks + 1
-		baseRepo.Downloaded = baseRepo.Downloaded + 1
 		UpdateRepository(baseRepo, true)
 	}
 	log.Info(fmt.Sprintf("%s is forked by %s (total: %d forked)", baseRepo.Name, owner.Name, baseRepo.NumForks))

--- a/internal/db/repo.go
+++ b/internal/db/repo.go
@@ -2522,8 +2522,8 @@ func ForkRepository(doer, owner *User, baseRepo *Repository, name, desc string) 
 		log.Error("PrepareWebhooks [repo_id: %d]: %v", baseRepo.ID, err)
 	}
 
-	if !baseRepo.IsOwnedBy(owner.ID) {
-		baseRepo.Downloaded = baseRepo.Downloaded + 1
+	if !baseRepo.IsOwnedBy(owner.ID) { //★
+		baseRepo.NumForks = baseRepo.NumForks + 1
 		UpdateRepository(baseRepo, true)
 	}
 	log.Info(baseRepo.Name + " is forked by " + owner.Name + " (total: " + strconv.FormatUint(baseRepo.Downloaded, 10) + " downloaded)")

--- a/internal/db/repo.go
+++ b/internal/db/repo.go
@@ -2524,9 +2524,10 @@ func ForkRepository(doer, owner *User, baseRepo *Repository, name, desc string) 
 
 	if !baseRepo.IsOwnedBy(owner.ID) { //★
 		baseRepo.NumForks = baseRepo.NumForks + 1
+		baseRepo.Downloaded = baseRepo.Downloaded + 1
 		UpdateRepository(baseRepo, true)
 	}
-	log.Info(baseRepo.Name + " is forked by " + owner.Name + " (total: " + strconv.FormatUint(baseRepo.Downloaded, 10) + " downloaded)")
+	log.Info(fmt.Sprintf("%s is forked by %s (total: %d forked)", baseRepo.Name, owner.Name, baseRepo.NumForks))
 	return repo, nil
 }
 


### PR DESCRIPTION
# Fork後のFork数が増加しないおよび、削除後のFork元の閲覧でPanicが発生する問題について

## バグ内容
- Forkされても、Fork元のFork数が増加しない（代わりにダウンロード数が増加する）
- Fork先が削除されると、Fork元のFork数がマイナス値をします。
- Fork数がマイナスになるとレポジトリが閲覧できなくなる。

## やったこと
- Fork時にFork元のFork数を1増加するようにした。
-  Fork時にFork元のダウンロード数を増加させないようにした。

## できるようになったこと
- ユーザのFork関連操作により、他ユーザの所有のリポジトリに影響がなくなった。

## 横展開
- Fork処理のLog出力を修正した。

## テスト
- Fork時にFork元のFork数を1増加することが確認できた。
- Fork時にFork元のダウンロード数を増加しないことを確認した。
- Fork先の削除後、Fork元のForkが-1され、閲覧できることを確認した。
