### PR TITLE
maDNP Templateブランチの指定化

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -232,9 +232,9 @@ func Init(customConf string) error {
 	}
 
 	// **************************
-	// ----- GitHub settings -----
+	// ----- DG settings -----
 	// **************************
-	if err = File.Section("github").MapTo(&GitHub); err != nil {
+	if err = File.Section("dg").MapTo(&DG); err != nil {
 		return errors.Wrap(err, "mapping [github] section")
 	}
 

--- a/internal/conf/static.go
+++ b/internal/conf/static.go
@@ -380,8 +380,9 @@ var (
 	}
 
 	// RCOS Specific Setting Struct
-	GitHub struct {
-		ApiToken string `ini:"API_TOKEN"`
+	DG struct {
+		ApiToken                string `ini:"GIT_API_TOKEN"`
+		MaDMPTemplateRepoBranch string `ini:"MA_DMP_TEMPLATE_BRANCH"`
 	}
 )
 

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -223,6 +223,7 @@ func (f repoUtil) FetchContentsOnGithub(c context.AbstructContext, blobPath stri
 	log.Trace("conf.DG.MaDMPTemplateRepoBranch : %s", conf.DG.MaDMPTemplateRepoBranch)
 	log.Trace("is Empty : %v", conf.DG.MaDMPTemplateRepoBranch != "")
 	apiToken := conf.DG.ApiToken
+	log.Trace("apiToken : %v", conf.DG.ApiToken)
 	log.Trace("apiToken : %v", apiToken)
 	if conf.DG.MaDMPTemplateRepoBranch != "" {
 		blobPath = blobPath + fmt.Sprintf("?ref=%s", conf.DG.MaDMPTemplateRepoBranch)

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -219,7 +219,17 @@ type AbstructRepoUtil interface {
 type repoUtil func()
 
 func (f repoUtil) FetchContentsOnGithub(c context.AbstructContext, blobPath string) ([]byte, error) {
-	return f.fetchContentsOnGithub(c, blobPath, conf.GitHub.ApiToken)
+	log.Trace("blobPath : %s", blobPath)
+	log.Trace("conf.DG.MaDMPTemplateRepoBranch : %s", conf.DG.MaDMPTemplateRepoBranch)
+	log.Trace("is Empty : %v", conf.DG.MaDMPTemplateRepoBranch != "")
+	apiToken := conf.DG.ApiToken
+	if conf.DG.MaDMPTemplateRepoBranch != "" {
+		blobPath = blobPath + fmt.Sprintf("?ref=%s", conf.DG.MaDMPTemplateRepoBranch)
+		log.Trace("[1 ]blobPath : %s", blobPath)
+		return f.fetchContentsOnGithub(c, blobPath, apiToken)
+	}
+	log.Trace("[2] blobPath : %s", blobPath)
+	return f.fetchContentsOnGithub(c, blobPath, apiToken)
 }
 
 func (f repoUtil) DecodeBlobContent(blobInfo []byte) (string, error) {

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -223,6 +223,7 @@ func (f repoUtil) FetchContentsOnGithub(c context.AbstructContext, blobPath stri
 	log.Trace("conf.DG.MaDMPTemplateRepoBranch : %s", conf.DG.MaDMPTemplateRepoBranch)
 	log.Trace("is Empty : %v", conf.DG.MaDMPTemplateRepoBranch != "")
 	apiToken := conf.DG.ApiToken
+	log.Trace("apiToken : %v", apiToken)
 	if conf.DG.MaDMPTemplateRepoBranch != "" {
 		blobPath = blobPath + fmt.Sprintf("?ref=%s", conf.DG.MaDMPTemplateRepoBranch)
 		log.Trace("[1 ]blobPath : %s", blobPath)

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -219,18 +219,11 @@ type AbstructRepoUtil interface {
 type repoUtil func()
 
 func (f repoUtil) FetchContentsOnGithub(c context.AbstructContext, blobPath string) ([]byte, error) {
-	log.Trace("blobPath : %s", blobPath)
-	log.Trace("conf.DG.MaDMPTemplateRepoBranch : %s", conf.DG.MaDMPTemplateRepoBranch)
-	log.Trace("is Empty : %v", conf.DG.MaDMPTemplateRepoBranch != "")
 	apiToken := conf.DG.ApiToken
-	log.Trace("apiToken : %v", conf.DG.ApiToken)
-	log.Trace("apiToken : %v", apiToken)
 	if conf.DG.MaDMPTemplateRepoBranch != "" {
 		blobPath = blobPath + fmt.Sprintf("?ref=%s", conf.DG.MaDMPTemplateRepoBranch)
-		log.Trace("[1 ]blobPath : %s", blobPath)
 		return f.fetchContentsOnGithub(c, blobPath, apiToken)
 	}
-	log.Trace("[2] blobPath : %s", blobPath)
 	return f.fetchContentsOnGithub(c, blobPath, apiToken)
 }
 


### PR DESCRIPTION
# maDNP Templateブランチの指定化

## やったこと
- テスト環境への対応のため、githubから外部ファイルを取得する際に、外部先のブランチを指定できるようにした。

## テスト
- Local環境で実施して想定の挙動になることを確認した。

## 横展開
- app.iniに変更あり
```
[dg]
GIT_API_TOKEN = {Token}
MA_DMP_TEMPLATE_BRANCH ={baranch}
```