### PR TITLE
コード付帯機能連携ボタンのgin-forkリポジトリアクセスURL修正

### DIFF
--- a/custom/templates/repo/header_gin.tmpl
+++ b/custom/templates/repo/header_gin.tmpl
@@ -12,7 +12,7 @@
 									<a class="ui basic button" href="{{$.RepoLink}}/src/{{EscapePound $.BranchName}}/maDMP.ipynb" data-position="bottom center"><i class="octicon octicon-file"></i>View maDMP</a>
 									<div class="ui labeled button" data-tooltip="Transition to the maDMP execution environment. Please click this after 'Generate maDMP'" data-position="bottom center">
                                 	<button class="ui basic button" data-position="bottom center">
-										<a href="https://binder.cs.rcos.nii.ac.jp/v2/git/http%3A%2F%2F{{.Domain}}%2F{{.Owner.Name}}%2F{{.Repository.Name}}.git/master?filepath=maDMP.ipynb">
+										<a href="https://binder.cs.rcos.nii.ac.jp/v2/git/{{.ExternalURL}}%2F{{.Owner.Name}}%2F{{.Repository.Name}}.git/master?filepath=maDMP.ipynb">
 											<img src="https://binder.cs.rcos.nii.ac.jp/badge_logo.svg">
 										</a>
 									</button>

--- a/custom/templates/repo/header_gin.tmpl
+++ b/custom/templates/repo/header_gin.tmpl
@@ -12,7 +12,7 @@
 									<a class="ui basic button" href="{{$.RepoLink}}/src/{{EscapePound $.BranchName}}/maDMP.ipynb" data-position="bottom center"><i class="octicon octicon-file"></i>View maDMP</a>
 									<div class="ui labeled button" data-tooltip="Transition to the maDMP execution environment. Please click this after 'Generate maDMP'" data-position="bottom center">
                                 	<button class="ui basic button" data-position="bottom center">
-										<a href="https://binder.cs.rcos.nii.ac.jp/v2/git/{{.ExternalURL}}%2F{{.Owner.Name}}%2F{{.Repository.Name}}.git/master?filepath=maDMP.ipynb">
+										<a href="https://binder.cs.rcos.nii.ac.jp/v2/git/{{.ginURL}}%2F{{.Owner.Name}}%2F{{.Repository.Name}}.git/master?filepath=maDMP.ipynb">
 											<img src="https://binder.cs.rcos.nii.ac.jp/badge_logo.svg">
 										</a>
 									</button>

--- a/internal/context/repo.go
+++ b/internal/context/repo.go
@@ -329,7 +329,7 @@ func RepoAssignment(pages ...bool) macaron.Handler {
 		c.Data["CloneLink"] = repo.CloneLink()
 		c.Data["WikiCloneLink"] = repo.WikiCloneLink()
 
-		c.Data["Domain"] = conf.Server.Domain
+		c.Data["ExternalURL"] = conf.Server.ExternalURL
 
 		if c.IsLogged {
 			c.Data["IsWatchingRepo"] = db.IsWatching(c.User.ID, repo.ID)

--- a/internal/context/repo.go
+++ b/internal/context/repo.go
@@ -328,8 +328,9 @@ func RepoAssignment(pages ...bool) macaron.Handler {
 		c.Data["ShowHTTP"] = conf.Repository.ShowHTTPGit
 		c.Data["CloneLink"] = repo.CloneLink()
 		c.Data["WikiCloneLink"] = repo.WikiCloneLink()
-
-		c.Data["ExternalURL"] = conf.Server.ExternalURL
+		u, _ := url.Parse(conf.Server.ExternalURL)
+		ginURL := fmt.Sprintf("%s://%s", u.Scheme, u.Host)
+		c.Data["ginURL"] = url.PathEscape(ginURL)
 
 		if c.IsLogged {
 			c.Data["IsWatchingRepo"] = db.IsWatching(c.User.ID, repo.ID)


### PR DESCRIPTION
# コード付帯機能連携ボタンのgin-forkリポジトリアクセスURL修正

## 修正内容
1. コード付帯機能連携ボタンのgin-forkリポジトリアクセスURL生成において、環境に依存しないように修正した

## テスト
1. 生成したURL埋めのボタンを押下。コード付帯機能でコンテナが立ち上がることを確認した。