### PR TITLE
add repository obj metadata to return metadata by API

### DIFF
--- a/internal/db/repo_metadata.go
+++ b/internal/db/repo_metadata.go
@@ -129,7 +129,7 @@ func ExtractMetaDataGitContent(repo *Repository, git_contents []gitcmd.DataDetai
 		r := sha256.Sum256(content)
 		hash := hex.EncodeToString(r[:])
 
-		url, err := repo.CreateAccessUrl(branch, git_content.FilePath)
+		url, err := repo.CreateAccessUrlToFile(branch, git_content.FilePath)
 		if err != nil {
 			return nil, err
 		}
@@ -176,7 +176,7 @@ func ExtractMetaDataGitAnnexContent(repo *Repository, git_annex_contents []gitcm
 			return nil, err
 		}
 
-		url, err := repo.CreateAccessUrl(branch, git_annex_content.FilePath)
+		url, err := repo.CreateAccessUrlToFile(branch, git_annex_content.FilePath)
 		if err != nil {
 			return nil, err
 		}
@@ -196,7 +196,7 @@ func ExtractMetaDataGitAnnexContent(repo *Repository, git_annex_contents []gitcm
 	return files, nil
 }
 
-func (repo *Repository) CreateAccessUrl(branch, file_path string) (string, error) {
+func (repo *Repository) CreateAccessUrlToFile(branch, file_path string) (string, error) {
 	urlPath := fmt.Sprintf("%s/src/%s/%s", repo.FullName(), branch, file_path)
 	url, err := urlutil.UpdatePath(conf.Server.ExternalURL, urlPath)
 	if err != nil {
@@ -218,7 +218,7 @@ func CreateFilesToDatasets(repo *Repository, files []datastruct.File, branch str
 		for _, element := range splited_file_path {
 			dataset_id = dataset_id + element + "/"
 			if _, ok := tmp_data[dataset_id]; !ok {
-				dataset_url, err := repo.CreateAccessUrl(branch, dataset_id)
+				dataset_url, err := repo.CreateAccessUrlToFile(branch, dataset_id)
 				if err != nil {
 					return nil, err
 				}
@@ -236,4 +236,26 @@ func CreateFilesToDatasets(repo *Repository, files []datastruct.File, branch str
 		datasets = append(datasets, v)
 	}
 	return datasets, nil
+}
+
+func (repo *Repository) CreateAccessUrlToRepo() (string, error) {
+	urlPath := fmt.Sprintf("%s", repo.FullName())
+	url, err := urlutil.UpdatePath(conf.Server.ExternalURL, urlPath)
+	if err != nil {
+		return "", err
+	}
+	return url, nil
+}
+
+func (repo *Repository) ExtractRepoMetadata() (datastruct.RepositoryObject, error) {
+	url, err := repo.CreateAccessUrlToRepo()
+	if err != nil {
+		return datastruct.RepositoryObject{}, err
+	}
+	return datastruct.RepositoryObject{
+		ID:          url,
+		Name:        repo.Name,
+		Description: repo.Description,
+	}, nil
+
 }

--- a/internal/route/api/v1/metadata/repo.go
+++ b/internal/route/api/v1/metadata/repo.go
@@ -143,7 +143,7 @@ func GetAllMetadataByRepoIDAndBranch(c *context.APIContext) {
 	// Create Files and Dataset
 	files, dataset, gin_monitoring, err := repo.ExtractMetadata(branch)
 	if err != nil {
-		log.Error("failure extracting metadata from repository <ID : %s>. err msg : %v", repoid_str, err)
+		log.Error("failure extracting metadata of data from repository <ID : %s>. err msg : %v", repoid_str, err)
 		c.JSON(http.StatusInternalServerError, map[string]interface{}{
 			"InternalServerError": "Internal Server Error",
 		})
@@ -170,12 +170,22 @@ func GetAllMetadataByRepoIDAndBranch(c *context.APIContext) {
 	//TODO : Create licenses
 	//TODO : Create data_downloads
 	//TODO : Create repository_objs
+
 	//TODO : Create hosting_institutions
 
 	// Create research_orgs
 	research_orgs := []datastruct.ResearchOrg{}
 	for _, v := range tmp_research_orgs {
 		research_orgs = append(research_orgs, v)
+	}
+
+	repo_obj, err := repo.ExtractRepoMetadata()
+	if err != nil {
+		log.Error("failure extracting repository metadata from repository <ID : %s>. err msg : %v", repoid_str, err)
+		c.JSON(http.StatusInternalServerError, map[string]interface{}{
+			"InternalServerError": "Internal Server Error",
+		})
+		return
 	}
 
 	// Create Metadata
@@ -185,7 +195,7 @@ func GetAllMetadataByRepoIDAndBranch(c *context.APIContext) {
 		ResearchOrgs:        research_orgs,
 		Licenses:            []datastruct.License{},
 		DataDownloads:       []datastruct.DataDownload{},
-		RepositoryObjects:   []datastruct.RepositoryObject{},
+		RepositoryObjects:   []datastruct.RepositoryObject{repo_obj},
 		HostingInstitutions: []datastruct.HostingInstitution{},
 		Persons:             persons,
 		Files:               files,


### PR DESCRIPTION
# PULL REQUEST

## Background

* API (/repos/repo_id/branchNm/metadata) to get all metadata in repository do not return repository obj metadata.

## Main Points of Modification

* Modify above API, to return repository obj metadata

## Test

* I confirmed that the API returned the expected response body.

## Viewpoint for Review

*　None

## Supplementary Information

* None

## ToDo

* None