### PR TITLE
Feature/health check

### DIFF
--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -36,6 +36,7 @@ import (
 	"github.com/NII-DG/gogs/internal/context"
 	"github.com/NII-DG/gogs/internal/db"
 	"github.com/NII-DG/gogs/internal/form"
+	"github.com/NII-DG/gogs/internal/healthcheck"
 	"github.com/NII-DG/gogs/internal/osutil"
 	"github.com/NII-DG/gogs/internal/route"
 	"github.com/NII-DG/gogs/internal/route/admin"
@@ -149,6 +150,10 @@ func newMacaron() *macaron.Macaron {
 			{
 				Desc: "Database connection",
 				Func: db.Ping,
+			},
+			{ // RCOS code
+				Desc: "File System connection",
+				Func: healthcheck.CheckFileSystem,
 			},
 		},
 	}))

--- a/internal/conf/static.go
+++ b/internal/conf/static.go
@@ -383,6 +383,8 @@ var (
 	DG struct {
 		ApiToken                string `ini:"GIT_API_TOKEN"`
 		MaDMPTemplateRepoBranch string `ini:"MA_DMP_TEMPLATE_BRANCH"`
+		HealthFilePath          string `ini:"HEALTH_FILE_PATH"`
+		HealthFileName          string `ini:"HEALTH_FILE_NAME"`
 	}
 )
 

--- a/internal/healthcheck/filesystem.go
+++ b/internal/healthcheck/filesystem.go
@@ -1,0 +1,8 @@
+package healthcheck
+
+/*
+ Check connecting File System
+*/
+func CheckFileSystem() error {
+	return nil
+}

--- a/internal/healthcheck/filesystem.go
+++ b/internal/healthcheck/filesystem.go
@@ -6,12 +6,17 @@ import (
 
 	"github.com/NII-DG/gogs/internal/conf"
 	"github.com/NII-DG/gogs/internal/utils"
+	log "unknwon.dev/clog/v2"
 )
 
 /*
  Check connecting File System
 */
 func CheckFileSystem() error {
+	if len(conf.DG.HealthFilePath) <= 0 || len(conf.DG.HealthFileName) <= 0 {
+		log.Trace("health check to file system is skip")
+		return nil
+	}
 	filepath := filepath.Join(conf.DG.HealthFilePath, conf.DG.HealthFileName)
 	if utils.ExistData(filepath) {
 		return nil

--- a/internal/healthcheck/filesystem.go
+++ b/internal/healthcheck/filesystem.go
@@ -21,6 +21,6 @@ func CheckFileSystem() error {
 	if utils.ExistData(filepath) {
 		return nil
 	} else {
-		return fmt.Errorf("Not exits %s for health check", filepath)
+		return fmt.Errorf("not exist %s for health check", filepath)
 	}
 }

--- a/internal/healthcheck/filesystem.go
+++ b/internal/healthcheck/filesystem.go
@@ -1,8 +1,21 @@
 package healthcheck
 
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/NII-DG/gogs/internal/conf"
+	"github.com/NII-DG/gogs/internal/utils"
+)
+
 /*
  Check connecting File System
 */
 func CheckFileSystem() error {
-	return nil
+	filepath := filepath.Join(conf.DG.HealthFilePath, conf.DG.HealthFileName)
+	if utils.ExistData(filepath) {
+		return nil
+	} else {
+		return fmt.Errorf("Not exits %s for health check", filepath)
+	}
 }

--- a/internal/route/install.go
+++ b/internal/route/install.go
@@ -425,7 +425,7 @@ func InstallPost(c *context.Context, f form.Install) {
 
 func HeathFileInit() error {
 	if len(conf.DG.HealthFilePath) <= 0 || len(conf.DG.HealthFileName) <= 0 {
-		log.Trace("Creating file for file system health check  is skip")
+		log.Trace("Creating file for file system health check is skip")
 		return nil
 	}
 

--- a/internal/route/install.go
+++ b/internal/route/install.go
@@ -424,6 +424,11 @@ func InstallPost(c *context.Context, f form.Install) {
 }
 
 func HeathFileInit() error {
+	if len(conf.DG.HealthFilePath) <= 0 || len(conf.DG.HealthFileName) <= 0 {
+		log.Trace("Creating file for file system health check  is skip")
+		return nil
+	}
+
 	dirpath := conf.DG.HealthFilePath
 	if !utils.ExistData(dirpath) {
 		if err := os.Mkdir(dirpath, os.ModePerm); err != nil {

--- a/internal/route/install.go
+++ b/internal/route/install.go
@@ -438,7 +438,7 @@ func HeathFileInit() error {
 	filepath := filepath.Join(dirpath, conf.DG.HealthFileName)
 	file, err := os.OpenFile(filepath, os.O_WRONLY|os.O_CREATE, os.ModePerm)
 	if err != nil {
-		return fmt.Errorf("failure to create File. filepaht : %s, err: %v", filepath, err)
+		return fmt.Errorf("failure to create File. file : %s, err: %v", filepath, err)
 	}
 	defer file.Close()
 	return nil

--- a/internal/utils/os.go
+++ b/internal/utils/os.go
@@ -2,7 +2,7 @@ package utils
 
 import "os"
 
-func ExistFile(name string) bool {
+func ExistData(name string) bool {
 	_, err := os.Stat(name)
 	return !os.IsNotExist(err)
 }

--- a/internal/utils/os.go
+++ b/internal/utils/os.go
@@ -1,0 +1,8 @@
+package utils
+
+import "os"
+
+func ExistFile(name string) bool {
+	_, err := os.Stat(name)
+	return !os.IsNotExist(err)
+}


### PR DESCRIPTION
# PULL REQUEST

## Background

* Health check of the connection to the mount storage destination was necessary

## Main Points of Modification

*　Added file storage connection confirmation function
　http://localhost/healthcheck is OK
![image](https://user-images.githubusercontent.com/96706614/223665460-755eb792-3a1a-4758-90ce-219d7303d8f6.png)
　http://localhost/healthcheck is NG
![image](https://user-images.githubusercontent.com/96706614/223665992-cce3b33f-a720-4135-840f-c2b223d21162.png)

* 　A value in the app.ini file (dg.HEALTH_FILE_PATH and dg.HEALTH_FILE_NAME) activates the health check, and the absence of either value disables it.

*  At startup of Gin, if dg.HEALTH_FILE_PATH and dg.HEALTH_FILE_NAME values are present, a file for health check is created in a specific path. If there is no value, the file is skipped. It is also skipped if the file already exists.

if in app.ini
```
[dg]
HEALTH_FILE_PATH = /data/gogs/mnt/health
HEALTH_FILE_NAME = health.txt
```
→create /data/gogs/mnt/health/health.txt

## Test

* いくつかのケースにおいて上記の機能が正常に動くことを確認した。
  1. Initial startup, with value
  2. Reboot, with value
  3. Initial startup, no value
  4. Reboot, no value

## Viewpoint for Review

* None

## Supplementary Information

* To enable file system health checks, include the following in app.ini
```
[dg]
HEALTH_FILE_PATH = mount path
HEALTH_FILE_NAME = file name
```

## ToDo

* None