### PR TITLE
Transit to top when canceling dmp new creation

### DIFF
--- a/custom/templates/repo/editor/commit_form.tmpl
+++ b/custom/templates/repo/editor/commit_form.tmpl
@@ -41,5 +41,5 @@
 	<button type="submit" id="commit" class="ui green button">
 		{{.i18n.Tr "repo.editor.commit_changes"}}
 	</button>
-	<a class="ui button red" href="{{EscapePound $.BranchLink}}/{{EscapePound .TreePath}}">{{.i18n.Tr "repo.editor.cancel"}}</a>
+	<a class="ui button red" href="{{EscapePound $.BranchLink}}{{if not .IsNewFile}}/{{EscapePound .TreePath}}{{end}}">{{.i18n.Tr "repo.editor.cancel"}}</a>
 </div>

--- a/internal/route/repo/editor.go
+++ b/internal/route/repo/editor.go
@@ -692,6 +692,7 @@ func createDmp(c context.AbstructContext, f AbstructRepoUtil, d AbstructDmpUtil)
 	c.CallData()["IsYAML"] = false
 	c.CallData()["IsJSON"] = true
 	c.CallData()["IsDmpJson"] = true
+	c.CallData()["IsNewFile"] = true
 
 	c.CallData()["FileContent"] = combinedDmp
 	c.CallData()["ParentTreePath"] = path.Dir(c.GetRepo().GetTreePath())


### PR DESCRIPTION
# PULL REQUEST

## Background

* Clicking the Cancel button when creating a new dmp causes a 404 error because it takes you to a page of uncreated files instead of the repository top.

## Main Points of Modification

* Set IsNewFile to true when creating a new dmp so that it returns to the repository top when canceling a new file.

## Test

* Tested in local environment.
* It was confirmed that cancellation on creating a new file will take the user to the repository top, and on updating the file, the user will be taken to the dmp file screen.

## Viewpoint for Review

* Nothing.

## Supplementary Information

* Nothing.

## ToDo

* Nothing.