### PR TITLE
fix to delete image file name

### DIFF
--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -390,7 +390,7 @@ func fetchImagefile(c context.AbstructContext) {
 
 	var f repoUtil
 
-	ImageFile := []string{"maDMP_to_workflow.jpg"}
+	ImageFile := []string{} //add the image file name if maDMP.ipynb has images.
 
 	for i := 0; i < len(ImageFile); i++ {
 		path := ImageFilePath + ImageFile[i]


### PR DESCRIPTION
# PULL REQUEST

## Background

* deleted the file for the maDMP.ipynb image, but it was not reflected in the GIN.

## Main Points of Modification

* Removed unnecessary file names.

## Test

* Confirmed that the relevant error is not displayed on local

## Viewpoint for Review

* None

## Supplementary Information

* None

## ToDo

* None