### PR TITLE
Feature/explore metadata

### DIFF
--- a/custom/templates/base/footer.tmpl
+++ b/custom/templates/base/footer.tmpl
@@ -7,7 +7,6 @@
         <footer>
             <div class="ui container">
                 <div class="ui center links item brand footertext">
-                    {{template "base/footer_gin_text" $}}
                     {{if .PageIsAdmin}}<span>{{.i18n.Tr "version"}}: {{AppVer}}</span>{{end}}
                     <div class="ui language bottom floating slide up dropdown link item" data-tooltip="Non-English translations may be incomplete">
                         <i class="world icon"></i>
@@ -18,6 +17,9 @@
                             {{end}}
                         </div>
                     </div>
+                </div>
+                <div class="ui center links item brand footertext">
+                    {{template "base/footer_gin_brand" $}}
                 </div>
             </div>
         </footer>

--- a/custom/templates/base/footer.tmpl
+++ b/custom/templates/base/footer.tmpl
@@ -1,0 +1,53 @@
+{{/*
+    <html>
+    <body>
+        <div>
+    */}}
+        </div>
+        <footer>
+            <div class="ui container">
+                <div class="ui center links item brand footertext">
+                    {{template "base/footer_gin_text" $}}
+                    {{if .PageIsAdmin}}<span>{{.i18n.Tr "version"}}: {{AppVer}}</span>{{end}}
+                    <div class="ui language bottom floating slide up dropdown link item" data-tooltip="Non-English translations may be incomplete">
+                        <i class="world icon"></i>
+                        <div class="text">{{.LangName}}</div>
+                        <div class="menu">
+                            {{range .AllLangs}}
+                                <a class="item {{if eq $.Lang .Lang}}active selected{{end}}" href="{{if eq $.Lang .Lang}}#{{else}}{{$.Link}}?lang={{.Lang}}{{end}}">{{.Name}}</a>
+                            {{end}}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </footer>
+    </body>
+    
+    <!-- Third-party libraries -->
+    {{if .RequireHighlightJS}}
+        <link rel="stylesheet" href="{{AppSubURL}}/plugins/highlight-9.18.0/github.css">
+        <script src="{{AppSubURL}}/plugins/highlight-9.18.0/highlight.pack.js"></script>
+        <script>hljs.initHighlightingOnLoad();</script>
+    {{end}}
+    {{if .RequireMinicolors}}
+        <link rel="stylesheet" href="{{AppSubURL}}/plugins/jquery.minicolors-2.2.3/jquery.minicolors.css">
+        <script src="{{AppSubURL}}/plugins/jquery.minicolors-2.2.3/jquery.minicolors.min.js"></script>
+    {{end}}
+    {{if .RequireDatetimepicker}}
+        <link rel="stylesheet" href="{{AppSubURL}}/plugins/jquery.datetimepicker-2.4.5/jquery.datetimepicker.css">
+        <script src="{{AppSubURL}}/plugins/jquery.datetimepicker-2.4.5/jquery.datetimepicker.js"></script>
+    {{end}}
+    {{if .RequireDropzone}}
+        <link rel="stylesheet" href="{{AppSubURL}}/plugins/dropzone-5.5.0/dropzone.min.css">
+        <script src="{{AppSubURL}}/plugins/dropzone-5.5.0/dropzone.min.js"></script>
+        <script>Dropzone.autoDiscover = false</script>
+    {{end}}
+    {{if .RequireAutosize}}
+        <script src="{{AppSubURL}}/plugins/autosize-4.0.2/autosize.min.js"></script>
+    {{end}}
+    <script src="{{AppSubURL}}/js/libs/emojify-1.1.0.min.js"></script>
+    <script src="{{AppSubURL}}/js/libs/clipboard-2.0.4.min.js"></script>
+    
+    {{template "inject/footer" .}}
+    </html>
+    

--- a/custom/templates/base/head_gin.tmpl
+++ b/custom/templates/base/head_gin.tmpl
@@ -1,0 +1,1 @@
+<a class="item" href="/G-Node/info/wiki" rel="noreferrer"><i class="octicon octicon-question"></i>{{.i18n.Tr "help"}}</a>

--- a/custom/templates/explore/search_metadata.tmpl
+++ b/custom/templates/explore/search_metadata.tmpl
@@ -4,8 +4,6 @@
         <select name="selectKey" style="width: 20%;">
             <option value="" selected>Select Key</option>
             <option value="schema">schema</option>
-            <option value="dmpType">dmpType</option>
-            <option value="agreementTitle">agreementTitle</option>
         </select>
 		<input name="q" value="{{.Keyword}}" placeholder="{{.i18n.Tr " explore.search"}}..." autofocus>
 		<button class="ui blue button">{{.i18n.Tr "explore.search"}}</button>

--- a/internal/route/home.go
+++ b/internal/route/home.go
@@ -58,13 +58,11 @@ func ExploreRepos(c *context.Context) {
 	c.Data["PageIsExploreRepositories"] = true
 
 	// for "Metadata" link on navbar
-	uname := c.GetCookie(conf.Security.CookieUsername)
-	if len(uname) == 0 {
+	if !c.IsLogged {
 		c.Data["IsUserFA"] = 0
 	} else {
 		c.Data["IsUserFA"] = (c.User.Type >= db.UserFA)
 	}
-
 	page := c.QueryInt("page")
 	if page <= 0 {
 		page = 1
@@ -114,8 +112,8 @@ func exploreMetadata(c context.AbstructContext) {
 	if page <= 0 {
 		page = 1
 	}
-
-	repos, count, err := db.SearchRepositoryByName(&db.SearchRepoOptions{
+	has_dmp_count := 0
+	repos, _, err := db.SearchRepositoryByName(&db.SearchRepoOptions{
 		Keyword:  "",
 		UserID:   c.UserID(),
 		OrderBy:  "updated_unix DESC",
@@ -162,13 +160,14 @@ func exploreMetadata(c context.AbstructContext) {
 			c.CallData()["SelectedKey"] = selectedKey
 			c.CallData()["SearchResult"] = keyword
 			repo.HasMetadata = true
+			has_dmp_count += 1
 		}
 	}
 
 	// below is search
 	c.CallData()["Keyword"] = keyword
-	c.CallData()["Total"] = count
-	c.CallData()["Page"] = paginater.New(int(count), conf.UI.ExplorePagingNum, page, 5)
+	c.CallData()["Total"] = has_dmp_count
+	c.CallData()["Page"] = paginater.New(int(has_dmp_count), conf.UI.ExplorePagingNum, page, 5)
 
 	if err = db.RepositoryList(repos).LoadAttributes(); err != nil {
 		c.Error(err, "load attributes")
@@ -236,6 +235,7 @@ func DmpBrowsing(c context.AbstructContext) {
 		c.CallData()["OwnerName"] = owner.Name
 		c.CallData()["RepoName"] = repoName
 		c.CallData()["DOIInfo"] = string(buf)
+		c.CallData()["IsUserFA"] = (c.GetUser().Type >= db.UserFA)
 	}
 	c.Success(DMP_BROWSING)
 }
@@ -302,8 +302,7 @@ func ExploreUsers(c *context.Context) {
 	c.Data["PageIsExploreUsers"] = true
 
 	// for "Metadata" link on navbar
-	uname := c.GetCookie(conf.Security.CookieUsername)
-	if len(uname) == 0 {
+	if !c.IsLogged {
 		c.Data["IsUserFA"] = 0
 	} else {
 		c.Data["IsUserFA"] = (c.User.Type >= db.UserFA)
@@ -325,8 +324,7 @@ func ExploreOrganizations(c *context.Context) {
 	c.Data["PageIsExploreOrganizations"] = true
 
 	// for "Metadata" link on navbar
-	uname := c.GetCookie(conf.Security.CookieUsername)
-	if len(uname) == 0 {
+	if !c.IsLogged {
 		c.Data["IsUserFA"] = 0
 	} else {
 		c.Data["IsUserFA"] = (c.User.Type >= db.UserFA)

--- a/internal/route/search_gin.go
+++ b/internal/route/search_gin.go
@@ -147,8 +147,7 @@ func ExploreData(c *context.Context) {
 	c.Data["PageIsExploreData"] = true
 
 	// for "Metadata" link on navbar
-	uname := c.GetCookie(conf.Security.CookieUsername)
-	if len(uname) == 0 {
+	if !c.IsLogged {
 		c.Data["IsUserFA"] = 0
 	} else {
 		c.Data["IsUserFA"] = (c.User.Type >= db.UserFA)
@@ -198,8 +197,7 @@ func ExploreCommits(c *context.Context) {
 	c.Data["PageIsExploreCommits"] = true
 
 	// for "Metadata" link on navbar
-	uname := c.GetCookie(conf.Security.CookieUsername)
-	if len(uname) == 0 {
+	if !c.IsLogged {
 		c.Data["IsUserFA"] = 0
 	} else {
 		c.Data["IsUserFA"] = (c.User.Type >= db.UserFA)


### PR DESCRIPTION
# PULL REQUEST

## Background

* Even for FA users, metadata is not displayed in the navigation bar after transitioning to the explorer tab.
The search key for the metadata search function is inappropriate. dmpType and agreementTitle are items only for meti, and are not effective as search targets.
* Unnecessary links are in the header and footer.

## Main Points of Modification

* For FA users, metadata is now displayed on the navigation bar of all explorer screens.
Removed dmpType and agreementTitle from search keys of metadata search function.
* Remove unnecessary links from headers and footers.

## Test

* In the local environment, FA users must be able to transition to the metadata search screen from the navigation bar. Confirmed that non-FA users do not see metadata search in the navigation bar. We also confirmed that schema is the only key for metadata search.
![image](https://user-images.githubusercontent.com/91708725/231970105-c0ecc054-5622-4278-8000-7dfd2910f7e0.png)
![image](https://user-images.githubusercontent.com/91708725/231970125-73d2c980-b691-4516-8504-02e83c059407.png)
* header
![image](https://user-images.githubusercontent.com/91708725/232022805-3f1fbb61-6fde-47ad-9c2a-11e2f1aa9e9d.png)
* footer
![image](https://user-images.githubusercontent.com/91708725/232022891-036e6227-08ea-4efd-8e0c-d282e2ebe160.png)


## Viewpoint for Review

* nothing special.

## Supplementary Information

* nothing special.

## ToDo

* nothing special.