### PR TITLE
handle accessing explore/metadata without login

### DIFF
--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -189,8 +189,8 @@ func runWeb(c *cli.Context) error {
 			m.Get("/repos", route.ExploreRepos)
 			m.Get("/users", route.ExploreUsers)
 			m.Get("/organizations", route.ExploreOrganizations)
-			m.Get("/_suggest/:keywords", route.ExploreSuggest) // GIN specific code
-			m.Get("/metadata", route.ExploreMetadata)          // RCOS specific code
+			m.Get("/_suggest/:keywords", route.ExploreSuggest)   // GIN specific code
+			m.Get("/metadata", reqSignIn, route.ExploreMetadata) // RCOS specific code
 			m.Group("/dmp", func() {
 				m.Get("/browsing/", route.DmpBrowsing)
 			})

--- a/internal/route/home.go
+++ b/internal/route/home.go
@@ -94,16 +94,20 @@ func ExploreRepos(c *context.Context) {
 }
 
 // ExploreMetadata is RCOS specific code
-func ExploreMetadata(c context.AbstructContext) {
-	exploreMetadata(c)
+func ExploreMetadata(c context.AbstructContext, con *context.Context) {
+	exploreMetadata(c, con)
 }
 
 // exploreMetadata is RCOS specific code
-func exploreMetadata(c context.AbstructContext) {
+func exploreMetadata(c context.AbstructContext, con *context.Context) {
 	c.CallData()["Title"] = c.Tr("explore")
 	c.CallData()["PageIsExplore"] = true
 	c.CallData()["PageIsExploreMetadata"] = true
-	c.CallData()["IsUserFA"] = (c.GetUser().Type >= db.UserFA)
+	if !con.IsLogged {
+		c.CallData()["IsUserFA"] = 0
+	} else {
+		c.CallData()["IsUserFA"] = (c.GetUser().Type >= db.UserFA)
+	}
 
 	selectedKey := c.Query("selectKey")
 	keyword := c.Query("q")

--- a/internal/route/home.go
+++ b/internal/route/home.go
@@ -94,20 +94,16 @@ func ExploreRepos(c *context.Context) {
 }
 
 // ExploreMetadata is RCOS specific code
-func ExploreMetadata(c context.AbstructContext, con *context.Context) {
-	exploreMetadata(c, con)
+func ExploreMetadata(c context.AbstructContext) {
+	exploreMetadata(c)
 }
 
 // exploreMetadata is RCOS specific code
-func exploreMetadata(c context.AbstructContext, con *context.Context) {
+func exploreMetadata(c context.AbstructContext) {
 	c.CallData()["Title"] = c.Tr("explore")
 	c.CallData()["PageIsExplore"] = true
 	c.CallData()["PageIsExploreMetadata"] = true
-	if !con.IsLogged {
-		c.CallData()["IsUserFA"] = 0
-	} else {
-		c.CallData()["IsUserFA"] = (c.GetUser().Type >= db.UserFA)
-	}
+	c.CallData()["IsUserFA"] = (c.GetUser().Type >= db.UserFA)
 
 	selectedKey := c.Query("selectKey")
 	keyword := c.Query("q")


### PR DESCRIPTION
# PULL REQUEST

## Background

* Panic occurs when accessing explore/metadata without logging in.

## Main Points of Modification

* If an un-logged-in user accesses /explore/metadata, ask for login

## Test

* In the local environment, when an un-logged-in user accesses /explore/metadata, the user is taken to the login screen. 
![image](https://user-images.githubusercontent.com/91708725/232473653-1cc00f9d-3e50-4159-b770-f7318124bd9c.png)

* On the login screen, we confirmed that an insufficient privilege error is displayed when the user logs in as a general user, and the metadata search screen is displayed when the user logs in as an FA user.
![image](https://user-images.githubusercontent.com/91708725/232473693-0a281f64-23d0-4a4e-96fb-1fedbd88cda5.png)
![image](https://user-images.githubusercontent.com/91708725/232473707-583d59b6-6d5e-4d01-96b6-3d106eb96297.png)


## Viewpoint for Review

* None in particular.

## Supplementary Information

* None in particular.

## ToDo

* None in particular.