### PR TITLE
auto-prepare initialfiles except license gitignore

### DIFF
--- a/custom/templates/repo/create.tmpl
+++ b/custom/templates/repo/create.tmpl
@@ -64,57 +64,6 @@
 						<span class="help">{{.i18n.Tr "repo.repo_description_length"}}: <span id="descLength"></span></span>
 					</div>
 
-					<div class="ui divider"></div>
-
-					<div class="inline field">
-						<label><h3>Initial files</h3></label>
-					</div>
-					<div class="inline field" data-tooltip={{.i18n.Tr "repo.repo_gitignore_tooltip"}}>
-						<label>.gitignore</label>
-						<a target="_blank" href="https://git-scm.com/docs/gitignore"><span class="octicon octicon-question"></span></a>
-						<div class="ui multiple search normal selection dropdown">
-							<input type="hidden" name="gitignores" value="{{.gitignores}}">
-							<div class="default text">{{.i18n.Tr "repo.repo_gitignore_helper"}}</div>
-							<div class="menu">
-								{{range .Gitignores}}
-									<div class="item" data-value="{{.}}">{{.}}</div>
-								{{end}}
-							</div>
-						</div>
-					</div>
-					<div class="inline field" data-tooltip={{.i18n.Tr "repo.license_tooltip"}}>
-						<label>{{.i18n.Tr "repo.license"}}</label>
-						<a target="_blank" href="/G-Node/Info/wiki/Licensing"><span class="octicon octicon-question"></span></a>
-						<div class="ui search selection dropdown">
-							<input type="hidden" name="license" value="{{index .Licenses 0}}">
-							<div class="default text">{{.i18n.Tr "repo.license_helper"}}</div>
-							<div class="menu">
-								{{range .Licenses}}
-									<div class="item" data-value="{{.}}">{{.}}</div>
-								{{end}}
-								<div class="item" data-value="">None</div>
-							</div>
-						</div>
-					</div>
-
-					<div class="inline field" data-tooltip={{.i18n.Tr "repo.readme_tooltip"}}>
-						<label>{{.i18n.Tr "repo.readme"}}</label>
-						<div class="ui selection dropdown">
-							<input type="hidden" name="readme" value="{{.readme}}">
-							<div class="default text">{{.i18n.Tr "repo.readme_helper"}}</div>
-							<div class="menu">
-								{{range .Readmes}}
-									<div class="item" data-value="{{.}}">{{.}}</div>
-								{{end}}
-							</div>
-						</div>
-					</div>
-					<div class="inline field">
-						<div class="ui checkbox" id="auto-init">
-							<input class="hidden" name="auto_init" type="checkbox" tabindex="0" {{if .auto_init}}checked{{end}}>
-							<label>{{.i18n.Tr "repo.auto_init"}}</label>
-						</div>
-					</div>
 					<!-- RCOS Code -->
 					<div class="ui divider"></div>
 					<div class="inline field">

--- a/internal/route/repo/repo.go
+++ b/internal/route/repo/repo.go
@@ -123,12 +123,12 @@ func CreatePost(c *context.Context, f form.CreateRepo) {
 	repo, err := db.CreateRepository(c.User, ctxUser, db.CreateRepoOptions{
 		Name:               f.RepoName,
 		Description:        f.Description,
-		Gitignores:         f.Gitignores,
-		License:            f.License,
-		Readme:             f.Readme,
+		Gitignores:         "",
+		License:            "",
+		Readme:             "Default",
 		IsPrivate:          f.Private || conf.Repository.ForcePrivate,
 		IsUnlisted:         f.Unlisted,
-		AutoInit:           f.AutoInit,
+		AutoInit:           true,
 		ProjectName:        f.ProjectName,
 		ProjectDescription: f.ProjectDescription,
 	})


### PR DESCRIPTION
# PULL REQUEST

## Background

* README.md and images/ need to be generated in the initial files on the system.
* LICENSE and .gitignore of initial files are not required.

## Main Points of Modification

* Improved to automatically prepare necessary files from a usability perspective.

## Test

* In the local environment, we confirmed that the repository creation form has been updated and that README.md and images are available after repository creation.

![image](https://github.com/NII-DG/gogs/assets/91708725/fe559e9e-e06d-44d2-ab1c-bb7da3b12323)
![image](https://github.com/NII-DG/gogs/assets/91708725/f0f7988f-a48f-4b16-980c-909b3c983d5f)


## Viewpoint for Review

*

## Supplementary Information

*

## ToDo

*