### PR TITLE
show error if dmp has no value

### DIFF
--- a/custom/conf/locale/locale_en-US.ini
+++ b/custom/conf/locale/locale_en-US.ini
@@ -1473,6 +1473,11 @@ upload_message = Drop files here or click to upload.<p>You can upload a maximum 
 server.connect.failure=Due to busy connections, we are unable to create or update DMPs or generate maDMPs at this time. Please try again in a few minutes.
 server.error=There is a failure in the system. Please contact the system administrator.
 branch.master=branch : master
+dmp.error = The following items are not entered in the DMP: %s.
+madmp.error.fetch = Failed to create maDMP. Please try again in a few minutes.
+madmp.error.read = Failed to create maDMP. Please contact the system administrator.
+madmp.error.exist = maDMP already exists.
+madmp.success = maDMP generated!
 
 [metadata]
 download.description=You can download this Repository(%s) by ZIP. But, a part of data that linked by link(git-annex or S3) can not be downloaded.

--- a/custom/conf/locale/locale_ja-JP.ini
+++ b/custom/conf/locale/locale_ja-JP.ini
@@ -1456,6 +1456,11 @@ remove_file=ファイル削除
 server.connect.failure=ただいま接続が混みあっているため、DMP作成および更新またmaDMPの生成ができません。しばらく時間をあけてお試し下さい。
 server.error=システム内で障害が発生しています。システム管理者にお問い合わせをお願いします。
 branch.master=ブランチ : master
+dmp.error = DMPには以下の項目が入力されていません: %s
+madmp.error.fetch = maDMPの作成に失敗しました。しばらく時間をあけて再度お試し下さい。
+madmp.error.read = maDMPの作成に失敗しました。システム管理者にお問い合わせをお願いします。
+madmp.error.exist = maDMPは既に存在しています。
+madmp.success = maDMPが作成されました。
 
 [metadata]
 download.description=リポジトリ（%s）をzip形式でダウンロードすることができます。ただし、リンク情報により紐づけられるデータは取得できないことに注意してください。

--- a/internal/assets/templates/templates_gen.go
+++ b/internal/assets/templates/templates_gen.go
@@ -15,7 +15,7 @@
 // ../../../templates/admin/user/edit.tmpl (5.459kB)
 // ../../../templates/admin/user/list.tmpl (1.879kB)
 // ../../../templates/admin/user/new.tmpl (2.811kB)
-// ../../../templates/base/alert.tmpl (457B)
+// ../../../templates/base/alert.tmpl (551B)
 // ../../../templates/base/delete_modal_actions.tmpl (261B)
 // ../../../templates/base/footer.tmpl (2.132kB)
 // ../../../templates/base/footer_gin_brand.tmpl (1.101kB)
@@ -534,7 +534,7 @@ func adminUserNewTmpl() (*asset, error) {
 	return a, nil
 }
 
-var _baseAlertTmpl = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x94\xcf\xb1\x0a\xc2\x30\x14\x85\xe1\x39\x79\x8a\xd0\x07\x68\xc1\x39\x66\x53\x14\xec\x54\xc1\x39\xb4\x69\xbc\x50\x93\x92\xdb\xd6\x21\xde\x77\x77\x50\xa8\x48\xaa\x74\x3e\xfc\x7c\x9c\x18\xa1\x15\xf9\xbe\xd3\x78\xcd\x77\x21\xf8\x50\xa2\x25\xe2\x4c\x36\x30\x89\xba\xd3\x88\xdb\x6c\x04\xe1\x8c\xd5\x03\x4c\x46\xdc\x0c\xa2\xb6\x26\x53\x9c\x31\xd9\xab\x18\xbf\x5a\xf1\x10\xd5\x10\x36\x87\x73\x79\x22\x92\x45\xaf\x38\x93\x45\x03\x93\xe2\x31\x1a\xd7\x10\xf1\x4f\xf1\xa2\x83\x03\x67\xd3\xe6\xfd\x35\x2e\x92\x73\xbc\x0e\xad\xc6\xba\x36\x88\x69\xb4\xf7\x08\x3f\x8f\xce\xf5\x3a\xf5\xe8\x5a\x9f\x26\xc1\xb5\x7e\x91\x7b\x67\xff\xad\x67\x00\x00\x00\xff\xff\xec\xcc\x9c\xbb\xc9\x01\x00\x00"
+var _baseAlertTmpl = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x94\xd1\xc1\x6a\x84\x30\x10\x06\xe0\x73\xf2\x14\xc1\x07\x50\xe8\x51\xd2\xdc\x5a\x5a\xa8\x27\x0b\x3d\x07\x8d\xe9\x80\x4d\x42\x46\xed\x21\x9b\x77\x5f\x50\x59\x97\xdd\xb8\x8b\xd7\xcc\xfc\x7c\x19\xfe\x10\xa0\x63\xf9\x7b\x2f\xf1\x37\x7f\xf3\xde\xfa\x0a\x75\x8c\x94\xf0\x16\x26\xd6\xf4\x12\xf1\x35\x1b\x81\x19\xa5\xe5\x00\x93\x62\x7f\x0a\x51\x6a\x95\x09\x4a\x08\x77\x22\x84\x9b\x2c\x3b\xb1\x7a\xf0\x2f\x1f\xdf\xd5\x57\x8c\xbc\x70\x82\x12\x5e\xb4\x30\x09\x1a\x82\x32\x6d\x8c\xf4\x5a\xfc\x91\xde\x80\xd1\x69\xf3\x7f\x19\xee\x92\x5b\xf8\x18\x5a\x8f\x4d\xa3\x10\xd3\xa8\xb3\x08\x0f\x0f\xdd\xd2\xc7\xd4\x4f\xd3\xd9\x34\x09\xa6\xb3\xbb\xdc\x1a\x7b\x6e\x51\xee\xc4\x5c\x42\x79\xd7\xc9\x9a\xe0\x4e\xac\x9f\x2f\x13\xd7\x6c\x4b\xf3\xe4\xb2\xb2\xbc\x9f\x03\x00\x00\xff\xff\xc3\x44\x51\x4e\x27\x02\x00\x00"
 
 func baseAlertTmplBytes() ([]byte, error) {
 	return bindataRead(
@@ -549,8 +549,8 @@ func baseAlertTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "base/alert.tmpl", size: 457, mode: os.FileMode(0644), modTime: time.Unix(1681812881, 0)}
-	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x2e, 0x82, 0xf9, 0x6, 0xef, 0x1b, 0x73, 0x38, 0xd, 0x6f, 0x4f, 0xd, 0x27, 0xc, 0xdc, 0xba, 0x5e, 0x77, 0x96, 0xf, 0x1e, 0xcd, 0x1, 0x5f, 0x62, 0x71, 0x2d, 0x8f, 0xb2, 0x9d, 0xe4, 0x96}}
+	info := bindataFileInfo{name: "base/alert.tmpl", size: 551, mode: os.FileMode(0644), modTime: time.Unix(1685930924, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xbe, 0x88, 0x5a, 0x65, 0xce, 0xe3, 0x8, 0x4d, 0x28, 0xbd, 0x5a, 0x55, 0x13, 0xc7, 0xe6, 0xda, 0x54, 0x24, 0xed, 0x89, 0x4e, 0x83, 0xa, 0x1d, 0x9e, 0x35, 0x69, 0xed, 0x6a, 0xe1, 0x5b, 0xdb}}
 	return a, nil
 }
 
@@ -2509,7 +2509,7 @@ func repoSettingsOptionsTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "repo/settings/options.tmpl", size: 19197, mode: os.FileMode(0644), modTime: time.Unix(1685354166, 0)}
+	info := bindataFileInfo{name: "repo/settings/options.tmpl", size: 19197, mode: os.FileMode(0644), modTime: time.Unix(1685693370, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x42, 0x10, 0xbe, 0x16, 0x66, 0xdf, 0x62, 0x90, 0x7c, 0x92, 0x66, 0x84, 0xc, 0xc6, 0x67, 0x12, 0xdc, 0x57, 0xdb, 0xe3, 0xbf, 0xfb, 0x2, 0xf9, 0x53, 0x9e, 0x80, 0xe7, 0x4d, 0x6, 0x1b, 0xcb}}
 	return a, nil
 }
@@ -3129,7 +3129,7 @@ func userDashboardDashboardTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "user/dashboard/dashboard.tmpl", size: 5176, mode: os.FileMode(0644), modTime: time.Unix(1685521439, 0)}
+	info := bindataFileInfo{name: "user/dashboard/dashboard.tmpl", size: 5176, mode: os.FileMode(0644), modTime: time.Unix(1685693370, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xa8, 0xbd, 0xf8, 0x18, 0x14, 0x3f, 0x18, 0x58, 0x7, 0xc7, 0x27, 0xb8, 0xa5, 0x4d, 0x13, 0x53, 0xdb, 0x23, 0x54, 0x36, 0x3f, 0x77, 0xf5, 0x63, 0x11, 0x65, 0x2e, 0x47, 0x3d, 0x8a, 0x8a, 0xf2}}
 	return a, nil
 }

--- a/internal/assets/templates/templates_gen.go
+++ b/internal/assets/templates/templates_gen.go
@@ -15,7 +15,7 @@
 // ../../../templates/admin/user/edit.tmpl (5.459kB)
 // ../../../templates/admin/user/list.tmpl (1.879kB)
 // ../../../templates/admin/user/new.tmpl (2.811kB)
-// ../../../templates/base/alert.tmpl (551B)
+// ../../../templates/base/alert.tmpl (456B)
 // ../../../templates/base/delete_modal_actions.tmpl (261B)
 // ../../../templates/base/footer.tmpl (2.132kB)
 // ../../../templates/base/footer_gin_brand.tmpl (1.101kB)
@@ -534,7 +534,7 @@ func adminUserNewTmpl() (*asset, error) {
 	return a, nil
 }
 
-var _baseAlertTmpl = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x94\xd1\xc1\x6a\x84\x30\x10\x06\xe0\x73\xf2\x14\xc1\x07\x50\xe8\x51\xd2\xdc\x5a\x5a\xa8\x27\x0b\x3d\x07\x8d\xe9\x80\x4d\x42\x46\xed\x21\x9b\x77\x5f\x50\x59\x97\xdd\xb8\x8b\xd7\xcc\xfc\x7c\x19\xfe\x10\xa0\x63\xf9\x7b\x2f\xf1\x37\x7f\xf3\xde\xfa\x0a\x75\x8c\x94\xf0\x16\x26\xd6\xf4\x12\xf1\x35\x1b\x81\x19\xa5\xe5\x00\x93\x62\x7f\x0a\x51\x6a\x95\x09\x4a\x08\x77\x22\x84\x9b\x2c\x3b\xb1\x7a\xf0\x2f\x1f\xdf\xd5\x57\x8c\xbc\x70\x82\x12\x5e\xb4\x30\x09\x1a\x82\x32\x6d\x8c\xf4\x5a\xfc\x91\xde\x80\xd1\x69\xf3\x7f\x19\xee\x92\x5b\xf8\x18\x5a\x8f\x4d\xa3\x10\xd3\xa8\xb3\x08\x0f\x0f\xdd\xd2\xc7\xd4\x4f\xd3\xd9\x34\x09\xa6\xb3\xbb\xdc\x1a\x7b\x6e\x51\xee\xc4\x5c\x42\x79\xd7\xc9\x9a\xe0\x4e\xac\x9f\x2f\x13\xd7\x6c\x4b\xf3\xe4\xb2\xb2\xbc\x9f\x03\x00\x00\xff\xff\xc3\x44\x51\x4e\x27\x02\x00\x00"
+var _baseAlertTmpl = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x94\xcf\xb1\x0a\xc2\x30\x14\x85\xe1\x39\x79\x8a\xd0\x07\x68\xc1\x39\x66\x53\x14\xec\x54\xc1\x39\xb4\x69\xbc\x50\x93\x92\xdb\xd6\x21\xde\x77\x77\x50\xa8\x48\xaa\x74\x3e\xfc\x7c\x9c\x18\xa1\x15\xf9\xbe\xd3\x78\xcd\x77\x21\xf8\x50\xa2\x25\xe2\x4c\x36\x30\x89\xba\xd3\x88\xdb\x6c\x04\xe1\x8c\xd5\x03\x4c\x46\xdc\x0c\xa2\xb6\x26\x53\x9c\x31\xd9\xab\x18\xbf\x5a\xf1\x10\xd5\x10\x36\x87\x73\x79\x22\x92\x45\xaf\x38\x93\x45\x03\x93\xe2\x31\x1a\xd7\x10\xf1\x4f\xf1\xa2\x83\x03\x67\xd3\xe6\xfd\x35\x2e\x92\x73\xbc\x0e\xad\xc6\xba\x36\x88\x69\xb4\xf7\x08\x3f\x8f\xce\xf5\x3a\xf5\xe8\x5a\x9f\x26\xc1\xb5\x7e\x91\x7b\x67\x7f\xad\x67\x00\x00\x00\xff\xff\x99\x9f\xe1\x98\xc8\x01\x00\x00"
 
 func baseAlertTmplBytes() ([]byte, error) {
 	return bindataRead(
@@ -549,8 +549,8 @@ func baseAlertTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "base/alert.tmpl", size: 551, mode: os.FileMode(0644), modTime: time.Unix(1685930924, 0)}
-	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xbe, 0x88, 0x5a, 0x65, 0xce, 0xe3, 0x8, 0x4d, 0x28, 0xbd, 0x5a, 0x55, 0x13, 0xc7, 0xe6, 0xda, 0x54, 0x24, 0xed, 0x89, 0x4e, 0x83, 0xa, 0x1d, 0x9e, 0x35, 0x69, 0xed, 0x6a, 0xe1, 0x5b, 0xdb}}
+	info := bindataFileInfo{name: "base/alert.tmpl", size: 456, mode: os.FileMode(0644), modTime: time.Unix(1685943792, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x93, 0x9b, 0x17, 0x14, 0x2, 0x73, 0xde, 0x37, 0x4b, 0xfa, 0xc8, 0x93, 0x23, 0xd4, 0x4b, 0x6b, 0x67, 0x23, 0x57, 0xa0, 0x3c, 0xbe, 0xf0, 0xed, 0x91, 0xc2, 0x8, 0x8f, 0xe0, 0x4e, 0xc8, 0xf1}}
 	return a, nil
 }
 
@@ -2509,7 +2509,7 @@ func repoSettingsOptionsTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "repo/settings/options.tmpl", size: 19197, mode: os.FileMode(0644), modTime: time.Unix(1685693370, 0)}
+	info := bindataFileInfo{name: "repo/settings/options.tmpl", size: 19197, mode: os.FileMode(0644), modTime: time.Unix(1685934347, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x42, 0x10, 0xbe, 0x16, 0x66, 0xdf, 0x62, 0x90, 0x7c, 0x92, 0x66, 0x84, 0xc, 0xc6, 0x67, 0x12, 0xdc, 0x57, 0xdb, 0xe3, 0xbf, 0xfb, 0x2, 0xf9, 0x53, 0x9e, 0x80, 0xe7, 0x4d, 0x6, 0x1b, 0xcb}}
 	return a, nil
 }
@@ -3129,7 +3129,7 @@ func userDashboardDashboardTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "user/dashboard/dashboard.tmpl", size: 5176, mode: os.FileMode(0644), modTime: time.Unix(1685693370, 0)}
+	info := bindataFileInfo{name: "user/dashboard/dashboard.tmpl", size: 5176, mode: os.FileMode(0644), modTime: time.Unix(1685934347, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xa8, 0xbd, 0xf8, 0x18, 0x14, 0x3f, 0x18, 0x58, 0x7, 0xc7, 0x27, 0xb8, 0xa5, 0x4d, 0x13, 0x53, 0xdb, 0x23, 0x54, 0x36, 0x3f, 0x77, 0xf5, 0x63, 0x11, 0x65, 0x2e, 0x47, 0x3d, 0x8a, 0x8a, 0xf2}}
 	return a, nil
 }

--- a/internal/route/repo/editor.go
+++ b/internal/route/repo/editor.go
@@ -704,6 +704,9 @@ func createDmp(c context.AbstructContext, f AbstructRepoUtil, d AbstructDmpUtil)
 	c.CallData()["PreviewableFileModes"] = strings.Join(conf.Repository.Editor.PreviewableFileModes, ",")
 	c.CallData()["EditorconfigURLPrefix"] = fmt.Sprintf("%s/api/v1/repos/%s/editorconfig/", conf.Server.Subpath, c.GetRepo().GetDbRepo().FullName())
 
+	log.Trace("schema: %v", c.CallData()["Schema"])
+	log.Trace("filecontent: %v", c.CallData()["FileContent"])
+
 	c.Success(tmplEditorEdit)
 }
 

--- a/internal/route/repo/editor.go
+++ b/internal/route/repo/editor.go
@@ -704,9 +704,6 @@ func createDmp(c context.AbstructContext, f AbstructRepoUtil, d AbstructDmpUtil)
 	c.CallData()["PreviewableFileModes"] = strings.Join(conf.Repository.Editor.PreviewableFileModes, ",")
 	c.CallData()["EditorconfigURLPrefix"] = fmt.Sprintf("%s/api/v1/repos/%s/editorconfig/", conf.Server.Subpath, c.GetRepo().GetDbRepo().FullName())
 
-	log.Trace("schema: %v", c.CallData()["Schema"])
-	log.Trace("filecontent: %v", c.CallData()["FileContent"])
-
 	c.Success(tmplEditorEdit)
 }
 

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -156,6 +156,23 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 		return
 	}
 
+	//===================================================ここから
+	fmt.Printf("dmp:%v\n", dmp)
+	fmt.Printf("decodedMaDmp:%v\n", decodedMaDmp)
+
+	// dmp.jsonに"fields"プロパティがある想定
+	property := []string{"workflowIdentifier", "contentSize", "datasetStructure", "useDocker"}
+	/* maDMPへ埋め込む情報を追加する際は
+	上記リストに追加すること
+	e.g.
+	hasGrdm
+	*/
+	selected := make(map[string]interface{})
+	for _, v := range property {
+		selected[v] = dmp.(map[string]interface{})[v]
+	}
+	//===================================================ここまで
+
 	// dmp.jsonに"fields"プロパティがある想定
 	selectedField := dmp.(map[string]interface{})["workflowIdentifier"]
 	selectedDataSize := dmp.(map[string]interface{})["contentSize"]
@@ -166,6 +183,24 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 	e.g.
 	hasGrdm := dmp.(map[string]interface{})["hasGrdm"]
 	*/
+
+	//===================================================ここから
+	// Check if the value is entered
+	var message string
+	for k, v := range selected {
+		if len(v.(string)) == 0 {
+			if len(message) == 0 {
+				message = k
+			} else {
+				message = message + "," + k
+			}
+		}
+	}
+	if len(message) > 0 {
+		failedGenereteMaDmp(c, "Sorry, faild gerate maDMP: DMP has no values for ["+message+"]")
+		return
+	}
+	//===================================================ここまで
 
 	pathToMaDmp := "maDMP.ipynb"
 	err = c.GetRepo().GetDbRepo().UpdateRepoFile(c.GetUser(), db.UpdateRepoFileOptions{

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -168,17 +168,6 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 		selected[v] = dmp.(map[string]interface{})[v]
 	}
 
-	// dmp.jsonに"fields"プロパティがある想定
-	selectedField := dmp.(map[string]interface{})["workflowIdentifier"]
-	selectedDataSize := dmp.(map[string]interface{})["contentSize"]
-	selectedDatasetStructure := dmp.(map[string]interface{})["datasetStructure"]
-	selectedUseDocker := dmp.(map[string]interface{})["useDocker"]
-	/* maDMPへ埋め込む情報を追加する際は
-	ここに追記のこと
-	e.g.
-	hasGrdm := dmp.(map[string]interface{})["hasGrdm"]
-	*/
-
 	// Check if the value is entered
 	var message string
 	for k, v := range selected {
@@ -186,12 +175,12 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 			if len(message) == 0 {
 				message = k
 			} else {
-				message = message + "," + k
+				message = message + ", " + k
 			}
 		}
 	}
 	if len(message) > 0 {
-		failedGenereteMaDmp(c, "Sorry, faild gerate maDMP: DMP has no values for ["+message+"]")
+		failedDmp(c, "Sorry, faild gerate maDMP: DMP has no values for [ "+message+" ]")
 		return
 	}
 
@@ -204,15 +193,15 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 		NewTreeName:  pathToMaDmp,
 		Message:      "[GIN] Generate maDMP",
 		Content: fmt.Sprintf(
-			decodedMaDmp,  // この行が埋め込み先: maDMP
-			selectedField, // ここより以下は埋め込む値: DMP情報
-			selectedDataSize,
-			selectedDatasetStructure,
-			selectedUseDocker,
+			decodedMaDmp,                   // この行が埋め込み先: maDMP
+			selected["workflowIdentifier"], // ここより以下は埋め込む値: DMP情報
+			selected["contentSize"],
+			selected["datasetStructure"],
+			selected["useDocker"],
 			/* maDMPへ埋め込む情報を追加する際は
 			ここに追記のこと
 			e.g.
-			hasGrdm, */
+			selected["hasGrdm"] */
 		),
 		IsNewFile: true,
 	})
@@ -224,7 +213,7 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 	}
 
 	/* Dockerfileか、binderフォルダを取得する。 */
-	if selectedUseDocker == "YES" {
+	if selected["useDocker"] == "YES" {
 		/* dockerファイルを取得する */
 		fetchDockerfile(c)
 	} else {
@@ -331,6 +320,11 @@ func (f repoUtil) decodeBlobContent(blobInfo []byte) (string, error) {
 func failedGenereteMaDmp(c context.AbstructContext, msg string) {
 	c.GetFlash().Error(msg)
 	c.Redirect(c.GetRepo().GetRepoLink())
+}
+
+func failedDmp(c context.AbstructContext, msg string) {
+	c.GetFlash().Error(msg)
+	c.Redirect(c.GetRepo().GetRepoLink() + "/_edit/" + c.GetRepo().GetBranchName() + "/dmp.json")
 }
 
 // fetchDockerfile is RCOS specific code.

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -156,22 +156,17 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 		return
 	}
 
-	//===================================================ここから
-	fmt.Printf("dmp:%v\n", dmp)
-	fmt.Printf("decodedMaDmp:%v\n", decodedMaDmp)
-
 	// dmp.jsonに"fields"プロパティがある想定
 	property := []string{"workflowIdentifier", "contentSize", "datasetStructure", "useDocker"}
 	/* maDMPへ埋め込む情報を追加する際は
 	上記リストに追加すること
 	e.g.
-	hasGrdm
+	, hasGrdm
 	*/
 	selected := make(map[string]interface{})
 	for _, v := range property {
 		selected[v] = dmp.(map[string]interface{})[v]
 	}
-	//===================================================ここまで
 
 	// dmp.jsonに"fields"プロパティがある想定
 	selectedField := dmp.(map[string]interface{})["workflowIdentifier"]
@@ -184,7 +179,6 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 	hasGrdm := dmp.(map[string]interface{})["hasGrdm"]
 	*/
 
-	//===================================================ここから
 	// Check if the value is entered
 	var message string
 	for k, v := range selected {
@@ -200,7 +194,6 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 		failedGenereteMaDmp(c, "Sorry, faild gerate maDMP: DMP has no values for ["+message+"]")
 		return
 	}
-	//===================================================ここまで
 
 	pathToMaDmp := "maDMP.ipynb"
 	err = c.GetRepo().GetDbRepo().UpdateRepoFile(c.GetUser(), db.UpdateRepoFileOptions{
@@ -242,9 +235,8 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 	/* 共通で使用する imageファイルを取得する */
 	fetchImagefile(c)
 
-	//c.GetFlash().Success("maDMP generated!")
-	//c.Redirect(c.GetRepo().GetRepoLink())
-	successGenereteMaDmp(c, "maDMP generated!")
+	c.GetFlash().Success("maDMP generated!")
+	c.Redirect(c.GetRepo().GetRepoLink())
 }
 
 type AbstructRepoUtil interface {
@@ -333,18 +325,11 @@ func (f repoUtil) decodeBlobContent(blobInfo []byte) (string, error) {
 	return string(decodedBlobContent), nil
 }
 
-func successGenereteMaDmp(c context.AbstructContext, msg string) {
-	c.GetFlash().SuccessMsg = msg
-	c.CallData()["Flash"] = c.GetFlash()
-	c.Redirect(c.GetRepo().GetRepoLink())
-}
-
 // failedGenerateMaDmp is RCOS specific code.
 // This is a function used by GenerateMaDmp to emit an error message
 // on UI when maDMP generation fails.
 func failedGenereteMaDmp(c context.AbstructContext, msg string) {
 	c.GetFlash().Error(msg)
-	c.CallData()["Flash"] = c.GetFlash()
 	c.Redirect(c.GetRepo().GetRepoLink())
 }
 

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -242,8 +242,9 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 	/* 共通で使用する imageファイルを取得する */
 	fetchImagefile(c)
 
-	c.GetFlash().Success("maDMP generated!")
-	c.Redirect(c.GetRepo().GetRepoLink())
+	//c.GetFlash().Success("maDMP generated!")
+	//c.Redirect(c.GetRepo().GetRepoLink())
+	successGenereteMaDmp(c, "maDMP generated!")
 }
 
 type AbstructRepoUtil interface {
@@ -332,11 +333,18 @@ func (f repoUtil) decodeBlobContent(blobInfo []byte) (string, error) {
 	return string(decodedBlobContent), nil
 }
 
+func successGenereteMaDmp(c context.AbstructContext, msg string) {
+	c.GetFlash().SuccessMsg = msg
+	c.CallData()["Flash"] = c.GetFlash()
+	c.Redirect(c.GetRepo().GetRepoLink())
+}
+
 // failedGenerateMaDmp is RCOS specific code.
 // This is a function used by GenerateMaDmp to emit an error message
 // on UI when maDMP generation fails.
 func failedGenereteMaDmp(c context.AbstructContext, msg string) {
 	c.GetFlash().Error(msg)
+	c.CallData()["Flash"] = c.GetFlash()
 	c.Redirect(c.GetRepo().GetRepoLink())
 }
 

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -123,7 +123,7 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 	decodedMaDmp, err = f.DecodeBlobContent(src)
 	if err != nil {
 		log.Error("maDMP blob could not be decorded: %v", err)
-		failedGenereteMaDmp(c, "Sorry, failed generate maDMP: fetching template failed")
+		failedGenereteMaDmp(c, c.Tr("madmp.error.fetch"))
 		return
 	}
 
@@ -136,14 +136,14 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 	if err != nil || entry == nil {
 		log.Error("dmp.json blob could not be retrieved: %v", err)
 
-		failedGenereteMaDmp(c, "Sorry, failed generate maDMP: DMP could not read")
+		failedGenereteMaDmp(c, c.Tr("rcos.madmp.error.read"))
 		return
 	}
 	buf, err := entry.Bytes()
 	if err != nil {
 		log.Error("dmp.json data could not be read: %v", err)
 
-		failedGenereteMaDmp(c, "Sorry, failed generate maDMP: DMP could not read")
+		failedGenereteMaDmp(c, c.Tr("rcos.madmp.error.read"))
 		return
 	}
 
@@ -152,7 +152,7 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 	if err != nil {
 		log.Error("Unmarshal DMP info: %v", err)
 
-		failedGenereteMaDmp(c, "Sorry, failed generate maDMP: DMP could not read")
+		failedGenereteMaDmp(c, c.Tr("rcos.madmp.error.read"))
 		return
 	}
 
@@ -164,20 +164,20 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 	, hasGrdm
 	*/
 	selected := make(map[string]interface{})
-	var message string
+	var errProperty string
 	for _, v := range property {
 		selected[v] = dmp.(map[string]interface{})[v]
 		// Check if the value is entered
 		if len(selected[v].(string)) == 0 {
-			if len(message) == 0 {
-				message = v
+			if len(errProperty) == 0 {
+				errProperty = v
 			} else {
-				message = message + ", " + v
+				errProperty = errProperty + ", " + v
 			}
 		}
 	}
-	if len(message) > 0 {
-		failedDmp(c, "Sorry, failed generate maDMP: DMP has no values for [ "+message+" ]")
+	if len(errProperty) > 0 {
+		failedDmp(c, c.Tr("rcos.dmp.error", errProperty))
 		return
 	}
 
@@ -204,8 +204,7 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 	})
 	if err != nil {
 		log.Error("failed generating maDMP: %v", err)
-
-		failedGenereteMaDmp(c, "failed generate maDMP: Already exist")
+		failedGenereteMaDmp(c, c.Tr("rcos.madmp.error.exist"))
 		return
 	}
 
@@ -221,7 +220,7 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 	/* 共通で使用する imageファイルを取得する */
 	fetchImagefile(c)
 
-	c.GetFlash().Success("maDMP generated!")
+	c.GetFlash().Success(c.Tr("rcos.madmp.success"))
 	c.Redirect(c.GetRepo().GetRepoLink())
 }
 

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -123,7 +123,7 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 	decodedMaDmp, err = f.DecodeBlobContent(src)
 	if err != nil {
 		log.Error("maDMP blob could not be decorded: %v", err)
-		failedGenereteMaDmp(c, "Sorry, faild gerate maDMP: fetching template failed")
+		failedGenereteMaDmp(c, "Sorry, failed generate maDMP: fetching template failed")
 		return
 	}
 
@@ -136,14 +136,14 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 	if err != nil || entry == nil {
 		log.Error("dmp.json blob could not be retrieved: %v", err)
 
-		failedGenereteMaDmp(c, "Sorry, faild gerate maDMP: DMP could not read")
+		failedGenereteMaDmp(c, "Sorry, failed generate maDMP: DMP could not read")
 		return
 	}
 	buf, err := entry.Bytes()
 	if err != nil {
 		log.Error("dmp.json data could not be read: %v", err)
 
-		failedGenereteMaDmp(c, "Sorry, faild gerate maDMP: DMP could not read")
+		failedGenereteMaDmp(c, "Sorry, failed generate maDMP: DMP could not read")
 		return
 	}
 
@@ -152,7 +152,7 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 	if err != nil {
 		log.Error("Unmarshal DMP info: %v", err)
 
-		failedGenereteMaDmp(c, "Sorry, faild gerate maDMP: DMP could not read")
+		failedGenereteMaDmp(c, "Sorry, failed generate maDMP: DMP could not read")
 		return
 	}
 
@@ -164,23 +164,20 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 	, hasGrdm
 	*/
 	selected := make(map[string]interface{})
+	var message string
 	for _, v := range property {
 		selected[v] = dmp.(map[string]interface{})[v]
-	}
-
-	// Check if the value is entered
-	var message string
-	for k, v := range selected {
-		if len(v.(string)) == 0 {
+		// Check if the value is entered
+		if len(selected[v].(string)) == 0 {
 			if len(message) == 0 {
-				message = k
+				message = v
 			} else {
-				message = message + ", " + k
+				message = message + ", " + v
 			}
 		}
 	}
 	if len(message) > 0 {
-		failedDmp(c, "Sorry, faild gerate maDMP: DMP has no values for [ "+message+" ]")
+		failedDmp(c, "Sorry, failed generate maDMP: DMP has no values for [ "+message+" ]")
 		return
 	}
 
@@ -208,7 +205,7 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 	if err != nil {
 		log.Error("failed generating maDMP: %v", err)
 
-		failedGenereteMaDmp(c, "Faild gerate maDMP: Already exist")
+		failedGenereteMaDmp(c, "failed generate maDMP: Already exist")
 		return
 	}
 
@@ -337,14 +334,14 @@ func fetchDockerfile(c context.AbstructContext) {
 	src, err := f.FetchContentsOnGithub(c, dockerfileUrl)
 	if err != nil {
 		log.Error("Dockerfile could not be fetched: %v", err)
-		failedGenereteMaDmp(c, "Sorry, faild gerate maDMP: fetching template failed(Dockerfile)")
+		failedGenereteMaDmp(c, "Sorry, failed generate maDMP: fetching template failed(Dockerfile)")
 		return
 	}
 
 	decodedDockerfile, err := f.DecodeBlobContent(src)
 	if err != nil {
 		log.Error("Dockerfile could not be decorded: %v", err)
-		failedGenereteMaDmp(c, "Sorry, faild gerate maDMP: fetching template failed(Dockerfile)")
+		failedGenereteMaDmp(c, "Sorry, failed generate maDMP: fetching template failed(Dockerfile)")
 		return
 	}
 
@@ -377,7 +374,7 @@ func fetchEmviromentfile(c context.AbstructContext) {
 		src, err := f.FetchContentsOnGithub(c, path)
 		if err != nil {
 			log.Error("%s could not be fetched: %v", Emviromentfile[i], err)
-			failedGenereteMaDmp(c, "Sorry, faild gerate maDMP: fetching template failed(Emviromentfile)")
+			failedGenereteMaDmp(c, "Sorry, failed generate maDMP: fetching template failed(Emviromentfile)")
 			return
 		}
 
@@ -385,7 +382,7 @@ func fetchEmviromentfile(c context.AbstructContext) {
 		if err != nil {
 			log.Error("%s could not be decorded: %v", Emviromentfile[i], err)
 
-			failedGenereteMaDmp(c, "Sorry, faild gerate maDMP: fetching template failed(Emviromentfile)")
+			failedGenereteMaDmp(c, "Sorry, failed generate maDMP: fetching template failed(Emviromentfile)")
 			return
 		}
 
@@ -419,7 +416,7 @@ func fetchImagefile(c context.AbstructContext) {
 		src, err := f.FetchContentsOnGithub(c, path)
 		if err != nil {
 			log.Error("%s could not be fetched: %v", ImageFile[i], err)
-			failedGenereteMaDmp(c, "Sorry, faild gerate maDMP: fetching template failed(ImageFile)")
+			failedGenereteMaDmp(c, "Sorry, failed generate maDMP: fetching template failed(ImageFile)")
 			return
 		}
 
@@ -427,7 +424,7 @@ func fetchImagefile(c context.AbstructContext) {
 		if err != nil {
 			log.Error("%s could not be decorded: %v", ImageFile[i], err)
 
-			failedGenereteMaDmp(c, "Sorry, faild gerate maDMP: fetching template failed(ImageFile)")
+			failedGenereteMaDmp(c, "Sorry, failed generate maDMP: fetching template failed(ImageFile)")
 			return
 		}
 

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -123,7 +123,7 @@ func generateMaDmp(c context.AbstructContext, f AbstructRepoUtil) {
 	decodedMaDmp, err = f.DecodeBlobContent(src)
 	if err != nil {
 		log.Error("maDMP blob could not be decorded: %v", err)
-		failedGenereteMaDmp(c, c.Tr("madmp.error.fetch"))
+		failedGenereteMaDmp(c, c.Tr("rcos.madmp.error.fetch"))
 		return
 	}
 

--- a/internal/route/repo/view.go
+++ b/internal/route/repo/view.go
@@ -383,11 +383,9 @@ func Home(c *context.Context) {
 			c.Data["ParentPath"] = "/" + paths[len(paths)-2]
 		}
 	}
-	log.Trace(".Flash_before%v", c.Data["Flash"])
 	if c.Data["Flash"] == nil {
 		c.Data["Flash"] = c.Flash
 	}
-	log.Trace(".Flash_after%v", c.Data["Flash"])
 	c.Data["Paths"] = paths
 	c.Data["TreeLink"] = treeLink
 	c.Data["TreeNames"] = treeNames

--- a/internal/route/repo/view.go
+++ b/internal/route/repo/view.go
@@ -82,7 +82,7 @@ func renderDirectory(c *context.Context, treeLink string) {
 			err := d.BidingDmpSchemaList(c, schemaUrl)
 			if err != nil && !c.IsInternalError() {
 				log.Warn("%v", err)
-				c.Flash.Warning(c.Tr("rcos.server.connect.failure"))
+				c.Flash.Warning(c.Tr("rcos.server.connect.failure"), true)
 			} else if err != nil && c.IsInternalError() {
 				log.Error(err.Error())
 				c.Error(fmt.Errorf(c.Tr("rcos.server.error")), "")
@@ -383,9 +383,7 @@ func Home(c *context.Context) {
 			c.Data["ParentPath"] = "/" + paths[len(paths)-2]
 		}
 	}
-	if c.Data["Flash"] == nil {
-		c.Data["Flash"] = c.Flash
-	}
+
 	c.Data["Paths"] = paths
 	c.Data["TreeLink"] = treeLink
 	c.Data["TreeNames"] = treeNames

--- a/internal/route/repo/view.go
+++ b/internal/route/repo/view.go
@@ -383,7 +383,11 @@ func Home(c *context.Context) {
 			c.Data["ParentPath"] = "/" + paths[len(paths)-2]
 		}
 	}
-	c.Data["Flash"] = c.Flash
+	log.Trace(".Flash_before%v", c.Data["Flash"])
+	if c.Data["Flash"] == nil {
+		c.Data["Flash"] = c.Flash
+	}
+	log.Trace(".Flash_after%v", c.Data["Flash"])
 	c.Data["Paths"] = paths
 	c.Data["TreeLink"] = treeLink
 	c.Data["TreeNames"] = treeNames

--- a/templates/base/alert.tmpl
+++ b/templates/base/alert.tmpl
@@ -18,7 +18,3 @@
 		<p>{{.Flash.InfoMsg | Str2HTML}}</p>
 	</div>
 {{end}}
-
-<p>Error:{{.Flash.ErrorMsg}}</p>
-<p>Success:{{.Flash.SuccessMsg}}</p>
-<p>Flash:{{.Flash}}</p>

--- a/templates/base/alert.tmpl
+++ b/templates/base/alert.tmpl
@@ -18,3 +18,7 @@
 		<p>{{.Flash.InfoMsg | Str2HTML}}</p>
 	</div>
 {{end}}
+
+<p>Error:{{.Flash.ErrorMsg}}</p>
+<p>Success:{{.Flash.SuccessMsg}}</p>
+<p>Flash:{{.Flash}}</p>


### PR DESCRIPTION
# PULL REQUEST

## Background

* DMPの項目の選択肢として未入力(--)を選択できてしまう。
* 「generate maDMP」を押下した際のメッセージが画面に届いていない。
* メッセージの綴りが間違っている。

## Main Points of Modification

* 必要な項目が未入力だった場合にエラーメッセージを表示させる。
* エラーの場合、メッセージを見ながら編集できるようにDMPの編集画面に遷移させる。
* generate maDMP成功時に成功メッセージを表示させる。
* メッセージの綴りを直す。

## Test
* ひとつだけ未選択のときに「generate maDMP」を押下した場合
![image](https://github.com/NII-DG/gogs/assets/108638856/0286e5d8-0984-405e-b81f-2418850d3508)

* 項目全未選択時に「generate maDMP」を押下した場合
![image](https://github.com/NII-DG/gogs/assets/108638856/83a91f6a-0846-4093-a85a-2f86d56bf3ef)

* 「generate maDMP」を押下し成功の場合
![image](https://github.com/NII-DG/gogs/assets/108638856/1cd192f7-d15d-4740-b736-042a338e69c1)


## Viewpoint for Review

* None

## Supplementary Information

* None

## ToDo

* None