### PR TITLE
他リポジトリ取得データのリンクURLのデコード漏れ

### DIFF
--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -526,7 +526,8 @@ func getWebContentURL(ctx *context.Context, key string) error {
 		ctx.Data["IsOtherRepositoryContent"] = true
 	} else {
 		// S3などGIN-fork以外のインターネット上に実データがある場合
-		ctx.Data["WebContentUrl"] = string(download_url)
+		decodeURL, _ := url.QueryUnescape(string(download_url))
+		ctx.Data["WebContentUrl"] = decodeURL
 		ctx.Data["IsWebContent"] = true
 	}
 	return err

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -525,6 +525,7 @@ func getWebContentURL(ctx *context.Context, key string) error {
 		src_download_url.Path = strings.Replace(u.Path, strings.Split(u.Path, "/")[3], "src", 1)
 		log.Trace("[DEBUG LOG] u.Path : %s", u.Path)
 		log.Trace("[DEBUG LOG] strings.Replace(u.Path, strings.Split(u.Path, \"/\")[3], \"src\", 1) : %s", strings.Replace(u.Path, strings.Split(u.Path, "/")[3], "src", 1))
+		log.Trace("[DEBUG LOG] src_download_url.String() : %s", src_download_url.String())
 		ctx.Data["WebContentUrl"] = src_download_url.String()
 		ctx.Data["IsOtherRepositoryContent"] = true
 	} else {

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -528,6 +528,8 @@ func getWebContentURL(ctx *context.Context, key string) error {
 		log.Trace("[DEBUG LOG] src_download_url.String() : %s", src_download_url.String())
 		c_url, _ := url.Parse(src_download_url.String())
 		log.Trace("[DEBUG LOG] c_url : %s", c_url)
+		encodedURL := url.QueryEscape(src_download_url.String())
+		log.Trace("[DEBUG LOG] encodedURL : %s", encodedURL)
 		ctx.Data["WebContentUrl"] = src_download_url.String()
 		ctx.Data["IsOtherRepositoryContent"] = true
 	} else {

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -532,7 +532,7 @@ func getWebContentURL(ctx *context.Context, key string) error {
 		log.Trace("[DEBUG LOG] encodedURL : %s", encodedURL)
 		decodeURL, _ := url.QueryUnescape(src_download_url.String())
 		log.Trace("[DEBUG LOG] decodeURL : %s", decodeURL)
-		ctx.Data["WebContentUrl"] = src_download_url.String()
+		ctx.Data["WebContentUrl"] = decodeURL
 		ctx.Data["IsOtherRepositoryContent"] = true
 	} else {
 		// S3などGIN-fork以外のインターネット上に実データがある場合

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -526,6 +526,8 @@ func getWebContentURL(ctx *context.Context, key string) error {
 		log.Trace("[DEBUG LOG] u.Path : %s", u.Path)
 		log.Trace("[DEBUG LOG] strings.Replace(u.Path, strings.Split(u.Path, \"/\")[3], \"src\", 1) : %s", strings.Replace(u.Path, strings.Split(u.Path, "/")[3], "src", 1))
 		log.Trace("[DEBUG LOG] src_download_url.String() : %s", src_download_url.String())
+		c_url, _ := url.Parse(src_download_url.String())
+		log.Trace("[DEBUG LOG] c_url : %s", c_url)
 		ctx.Data["WebContentUrl"] = src_download_url.String()
 		ctx.Data["IsOtherRepositoryContent"] = true
 	} else {

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -530,6 +530,8 @@ func getWebContentURL(ctx *context.Context, key string) error {
 		log.Trace("[DEBUG LOG] c_url : %s", c_url)
 		encodedURL := url.QueryEscape(src_download_url.String())
 		log.Trace("[DEBUG LOG] encodedURL : %s", encodedURL)
+		decodeURL, _ := url.QueryUnescape(src_download_url.String())
+		log.Trace("[DEBUG LOG] decodeURL : %s", decodeURL)
 		ctx.Data["WebContentUrl"] = src_download_url.String()
 		ctx.Data["IsOtherRepositoryContent"] = true
 	} else {

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -514,6 +514,8 @@ func getWebContentURL(ctx *context.Context, key string) error {
 	location = location[start+len("web: "):]
 	end := strings.Index(string(location), "\n")
 	download_url := location[:end]
+	log.Trace("[DEBUG LOG] download_url : %s", download_url)
+	log.Trace("[DEBUG LOG] string(download_url) : %s", string(download_url))
 	u, _ := url.Parse(string(download_url))
 	if u.Hostname() == conf.Server.Domain {
 		// GIN-forkの実データがaddurlされている場合は、実データファイルの閲覧画面をリンクする
@@ -521,6 +523,8 @@ func getWebContentURL(ctx *context.Context, key string) error {
 		src_download_url.Scheme = u.Scheme
 		src_download_url.Host = u.Host
 		src_download_url.Path = strings.Replace(u.Path, strings.Split(u.Path, "/")[3], "src", 1)
+		log.Trace("[DEBUG LOG] u.Path : %s", u.Path)
+		log.Trace("[DEBUG LOG] strings.Replace(u.Path, strings.Split(u.Path, \"/\")[3], \"src\", 1) : %s", strings.Replace(u.Path, strings.Split(u.Path, "/")[3], "src", 1))
 		ctx.Data["WebContentUrl"] = src_download_url.String()
 		ctx.Data["IsOtherRepositoryContent"] = true
 	} else {

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -514,8 +514,6 @@ func getWebContentURL(ctx *context.Context, key string) error {
 	location = location[start+len("web: "):]
 	end := strings.Index(string(location), "\n")
 	download_url := location[:end]
-	log.Trace("[DEBUG LOG] download_url : %s", download_url)
-	log.Trace("[DEBUG LOG] string(download_url) : %s", string(download_url))
 	u, _ := url.Parse(string(download_url))
 	if u.Hostname() == conf.Server.Domain {
 		// GIN-forkの実データがaddurlされている場合は、実データファイルの閲覧画面をリンクする
@@ -523,20 +521,11 @@ func getWebContentURL(ctx *context.Context, key string) error {
 		src_download_url.Scheme = u.Scheme
 		src_download_url.Host = u.Host
 		src_download_url.Path = strings.Replace(u.Path, strings.Split(u.Path, "/")[3], "src", 1)
-		log.Trace("[DEBUG LOG] u.Path : %s", u.Path)
-		log.Trace("[DEBUG LOG] strings.Replace(u.Path, strings.Split(u.Path, \"/\")[3], \"src\", 1) : %s", strings.Replace(u.Path, strings.Split(u.Path, "/")[3], "src", 1))
-		log.Trace("[DEBUG LOG] src_download_url.String() : %s", src_download_url.String())
-		c_url, _ := url.Parse(src_download_url.String())
-		log.Trace("[DEBUG LOG] c_url : %s", c_url)
-		encodedURL := url.QueryEscape(src_download_url.String())
-		log.Trace("[DEBUG LOG] encodedURL : %s", encodedURL)
 		decodeURL, _ := url.QueryUnescape(src_download_url.String())
-		log.Trace("[DEBUG LOG] decodeURL : %s", decodeURL)
 		ctx.Data["WebContentUrl"] = decodeURL
 		ctx.Data["IsOtherRepositoryContent"] = true
 	} else {
 		// S3などGIN-fork以外のインターネット上に実データがある場合
-		log.Trace("[DEBUG LOG] S3 string(download_url) : %s", string(download_url))
 		ctx.Data["WebContentUrl"] = string(download_url)
 		ctx.Data["IsWebContent"] = true
 	}

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -536,6 +536,7 @@ func getWebContentURL(ctx *context.Context, key string) error {
 		ctx.Data["IsOtherRepositoryContent"] = true
 	} else {
 		// S3などGIN-fork以外のインターネット上に実データがある場合
+		log.Trace("[DEBUG LOG] S3 string(download_url) : %s", string(download_url))
 		ctx.Data["WebContentUrl"] = string(download_url)
 		ctx.Data["IsWebContent"] = true
 	}


### PR DESCRIPTION
# PULL REQUEST

## Background

* RF上で他リポジトリからデータ取得後、Gin-forkUIから取得データの閲覧ができない問題。404エラーになる。
* リンクURLデコード漏れが原因

## Main Points of Modification

* HTMLにリンクを渡す直前にURLのデコード処理を追加した。

## テスト
* ターミナル、他リポジトリ、S3から保存したデータが閲覧できることを確認した。
![image](https://github.com/NII-DG/gogs/assets/96706614/db7bb7ee-7aea-4186-a52f-7d6d3bca4fff)
![image](https://github.com/NII-DG/gogs/assets/96706614/d66f1383-7342-4f99-aec9-c79dfdbd650e)
![image](https://github.com/NII-DG/gogs/assets/96706614/25cd0864-9aa8-437e-a548-9930e8b02150)
