### PR TITLE
Feature/usability remark 44 debug

### DIFF
--- a/custom/conf/locale/locale_en-US.ini
+++ b/custom/conf/locale/locale_en-US.ini
@@ -59,7 +59,7 @@ cancel = Cancel
 research_project_title=Research Project
 project_name=Research Project Name
 project_description=Research Project Description
-available_length = Available characters
+available_length = Available characters(Line breaks count as two characters.)
 
 [status]
 page_not_found = Page Not Found
@@ -463,7 +463,7 @@ watchers = Watchers
 stargazers = Stargazers
 forks = Forks
 repo_description_helper = The title of the dataset or other brief sentence to describe what the repository is about. Maximum 512 characters length.
-repo_description_length =  Available characters
+repo_description_length =  Available characters(Line breaks count as two characters.)
 
 form.reach_limit_of_creation = The owner has reached maximum creation limit of %d repositories.
 form.name_not_allowed = Repository name or pattern %q is not allowed.
@@ -916,7 +916,7 @@ settings.deploy_key_deletion = Delete Deploy Key
 settings.deploy_key_deletion_desc = Deleting this deploy key will remove all related accesses for this repository. Do you want to continue?
 settings.deploy_key_deletion_success = Deploy key has been deleted successfully!
 settings.description_desc = The title of the dataset or other brief sentence to describe what the repository is about. Maximum 512 characters length.
-settings.description_length = Available characters
+settings.description_length = Available characters(Line breaks count as two characters.)
 
 settings.project=Research Project
 settings.project_settings=Research Project Settings

--- a/custom/conf/locale/locale_en-US.ini
+++ b/custom/conf/locale/locale_en-US.ini
@@ -59,7 +59,7 @@ cancel = Cancel
 research_project_title=Research Project
 project_name=Research Project Name
 project_description=Research Project Description
-available_length = Available bytes
+available_length = Available characters
 
 [status]
 page_not_found = Page Not Found
@@ -462,7 +462,7 @@ watchers = Watchers
 stargazers = Stargazers
 forks = Forks
 repo_description_helper = The title of the dataset or other brief sentence to describe what the repository is about. Maximum 512 characters length.
-repo_description_length =  Available bytes
+repo_description_length =  Available characters
 
 form.reach_limit_of_creation = The owner has reached maximum creation limit of %d repositories.
 form.name_not_allowed = Repository name or pattern %q is not allowed.
@@ -915,7 +915,7 @@ settings.deploy_key_deletion = Delete Deploy Key
 settings.deploy_key_deletion_desc = Deleting this deploy key will remove all related accesses for this repository. Do you want to continue?
 settings.deploy_key_deletion_success = Deploy key has been deleted successfully!
 settings.description_desc = The title of the dataset or other brief sentence to describe what the repository is about. Maximum 512 characters length.
-settings.description_length = Available bytes
+settings.description_length = Available characters
 
 settings.project=Research Project
 settings.project_settings=Research Project Settings

--- a/custom/conf/locale/locale_en-US.ini
+++ b/custom/conf/locale/locale_en-US.ini
@@ -265,6 +265,7 @@ enterred_invalid_password = Please make sure the that password you entered is co
 user_not_exist = Given user does not exist.
 invite_email_blocked=User invitation failed. Please contact the site administrators.
 last_org_owner = Removing the last remaining user from an owner team is not allowed, as an organization must always have at least one owner.
+projectname_has_no_char = Research Project Name must include letters of the alphabet or Japanese (hiragana, katakana, and kanji).
 
 invalid_ssh_key = Sorry, verification of your SSH key failed: %s
 unable_verify_ssh_key = GIN cannot verify your SSH key, but it's assumed to be valid. Please double-check it.

--- a/custom/conf/locale/locale_en-US.ini
+++ b/custom/conf/locale/locale_en-US.ini
@@ -59,7 +59,7 @@ cancel = Cancel
 research_project_title=Research Project
 project_name=Research Project Name
 project_description=Research Project Description
-available_length = Available characters(Line breaks count as two characters.)
+available_length = Available characters
 
 [status]
 page_not_found = Page Not Found
@@ -463,7 +463,7 @@ watchers = Watchers
 stargazers = Stargazers
 forks = Forks
 repo_description_helper = The title of the dataset or other brief sentence to describe what the repository is about. Maximum 512 characters length.
-repo_description_length =  Available characters(Line breaks count as two characters.)
+repo_description_length =  Available characters
 
 form.reach_limit_of_creation = The owner has reached maximum creation limit of %d repositories.
 form.name_not_allowed = Repository name or pattern %q is not allowed.
@@ -916,7 +916,7 @@ settings.deploy_key_deletion = Delete Deploy Key
 settings.deploy_key_deletion_desc = Deleting this deploy key will remove all related accesses for this repository. Do you want to continue?
 settings.deploy_key_deletion_success = Deploy key has been deleted successfully!
 settings.description_desc = The title of the dataset or other brief sentence to describe what the repository is about. Maximum 512 characters length.
-settings.description_length = Available characters(Line breaks count as two characters.)
+settings.description_length = Available characters
 
 settings.project=Research Project
 settings.project_settings=Research Project Settings

--- a/custom/conf/locale/locale_ja-JP.ini
+++ b/custom/conf/locale/locale_ja-JP.ini
@@ -57,7 +57,7 @@ cancel=キャンセル
 research_project_title=研究プロジェクト
 project_name=研究プロジェクト名
 project_description=研究プロジェクトの説明
-available_length=利用可能なbyte数
+available_length=利用可能な文字数
 
 [status]
 page_not_found=Page Not Found
@@ -457,7 +457,7 @@ watchers=ウォッチャー
 stargazers=スターゲイザー
 forks=フォーク
 repo_description_helper=リポジトリの説明 (512文字以内)
-repo_description_length=利用可能なbyte数
+repo_description_length=利用可能な文字数
 
 form.reach_limit_of_creation=リポジトリの最大作成数 %d にすでに達しています。
 form.name_not_allowed=Repository name or pattern %q is not allowed.
@@ -900,7 +900,7 @@ settings.deploy_key_deletion=デプロイキーを削除
 settings.deploy_key_deletion_desc=このデプロイキーを削除すると、このリポジトリに関連するすべてのアクセス権も削除されます。続行しますか。
 settings.deploy_key_deletion_success=デプロイキーが正常に削除された!
 settings.description_desc=リポジトリの説明(512文字以内)
-settings.description_length=利用可能なbyte数
+settings.description_length=利用可能な文字数
 settings.project=研究プロジェクト
 settings.project_settings=研究プロジェクトの設定
 settings.update_project_success=研究プロジェクトの設定が更新されました。

--- a/custom/conf/locale/locale_ja-JP.ini
+++ b/custom/conf/locale/locale_ja-JP.ini
@@ -57,7 +57,7 @@ cancel=キャンセル
 research_project_title=研究プロジェクト
 project_name=研究プロジェクト名
 project_description=研究プロジェクトの説明
-available_length=利用可能な文字数(改行は2文字とカウントします)
+available_length=利用可能な文字数
 
 [status]
 page_not_found=Page Not Found
@@ -458,7 +458,7 @@ watchers=ウォッチャー
 stargazers=スターゲイザー
 forks=フォーク
 repo_description_helper=リポジトリの説明 (512文字以内)
-repo_description_length=利用可能な文字数(改行は2文字とカウントします)
+repo_description_length=利用可能な文字数
 
 form.reach_limit_of_creation=リポジトリの最大作成数 %d にすでに達しています。
 form.name_not_allowed=Repository name or pattern %q is not allowed.
@@ -901,7 +901,7 @@ settings.deploy_key_deletion=デプロイキーを削除
 settings.deploy_key_deletion_desc=このデプロイキーを削除すると、このリポジトリに関連するすべてのアクセス権も削除されます。続行しますか。
 settings.deploy_key_deletion_success=デプロイキーが正常に削除された!
 settings.description_desc=リポジトリの説明(512文字以内)
-settings.description_length=利用可能な文字数(改行は2文字とカウントします)
+settings.description_length=利用可能な文字数
 settings.project=研究プロジェクト
 settings.project_settings=研究プロジェクトの設定
 settings.update_project_success=研究プロジェクトの設定が更新されました。

--- a/custom/conf/locale/locale_ja-JP.ini
+++ b/custom/conf/locale/locale_ja-JP.ini
@@ -57,7 +57,7 @@ cancel=キャンセル
 research_project_title=研究プロジェクト
 project_name=研究プロジェクト名
 project_description=研究プロジェクトの説明
-available_length=利用可能な文字数(改行は2文字としてカウントする)
+available_length=利用可能な文字数(改行は2文字とカウントします)
 
 [status]
 page_not_found=Page Not Found
@@ -458,7 +458,7 @@ watchers=ウォッチャー
 stargazers=スターゲイザー
 forks=フォーク
 repo_description_helper=リポジトリの説明 (512文字以内)
-repo_description_length=利用可能な文字数(改行は2文字としてカウントする)
+repo_description_length=利用可能な文字数(改行は2文字とカウントします)
 
 form.reach_limit_of_creation=リポジトリの最大作成数 %d にすでに達しています。
 form.name_not_allowed=Repository name or pattern %q is not allowed.
@@ -901,7 +901,7 @@ settings.deploy_key_deletion=デプロイキーを削除
 settings.deploy_key_deletion_desc=このデプロイキーを削除すると、このリポジトリに関連するすべてのアクセス権も削除されます。続行しますか。
 settings.deploy_key_deletion_success=デプロイキーが正常に削除された!
 settings.description_desc=リポジトリの説明(512文字以内)
-settings.description_length=利用可能な文字数(改行は2文字としてカウントする)
+settings.description_length=利用可能な文字数(改行は2文字とカウントします)
 settings.project=研究プロジェクト
 settings.project_settings=研究プロジェクトの設定
 settings.update_project_success=研究プロジェクトの設定が更新されました。

--- a/custom/conf/locale/locale_ja-JP.ini
+++ b/custom/conf/locale/locale_ja-JP.ini
@@ -263,6 +263,7 @@ enterred_invalid_owner_name=入力された所有者名が正しいかどうか�
 enterred_invalid_password=入力したパスワードが正しいか確認してください。
 user_not_exist=指定されたユーザーは存在しません。
 last_org_owner=所有者のチームから最後のユーザーを削除することはできません。組織には常に最低でも1人の所有者が必要です。
+projectname_has_no_char=研究プロジェクト名は、アルファベットもしくは日本語（ひらがな・カタカナ・漢字）を含む必要があります。
 
 invalid_ssh_key=申し訳ございませんが、SSH キーを検証することができません: %s
 unable_verify_ssh_key=GINはあなたのSSH keyを確認できません。しかし、我々は有効とみなしますので、自分自身で確認してください。

--- a/custom/conf/locale/locale_ja-JP.ini
+++ b/custom/conf/locale/locale_ja-JP.ini
@@ -57,7 +57,7 @@ cancel=キャンセル
 research_project_title=研究プロジェクト
 project_name=研究プロジェクト名
 project_description=研究プロジェクトの説明
-available_length=利用可能な文字数
+available_length=利用可能な文字数(改行は2文字としてカウントする)
 
 [status]
 page_not_found=Page Not Found
@@ -458,7 +458,7 @@ watchers=ウォッチャー
 stargazers=スターゲイザー
 forks=フォーク
 repo_description_helper=リポジトリの説明 (512文字以内)
-repo_description_length=利用可能な文字数
+repo_description_length=利用可能な文字数(改行は2文字としてカウントする)
 
 form.reach_limit_of_creation=リポジトリの最大作成数 %d にすでに達しています。
 form.name_not_allowed=Repository name or pattern %q is not allowed.
@@ -901,7 +901,7 @@ settings.deploy_key_deletion=デプロイキーを削除
 settings.deploy_key_deletion_desc=このデプロイキーを削除すると、このリポジトリに関連するすべてのアクセス権も削除されます。続行しますか。
 settings.deploy_key_deletion_success=デプロイキーが正常に削除された!
 settings.description_desc=リポジトリの説明(512文字以内)
-settings.description_length=利用可能な文字数
+settings.description_length=利用可能な文字数(改行は2文字としてカウントする)
 settings.project=研究プロジェクト
 settings.project_settings=研究プロジェクトの設定
 settings.update_project_success=研究プロジェクトの設定が更新されました。

--- a/custom/templates/org/settings/options.tmpl
+++ b/custom/templates/org/settings/options.tmpl
@@ -22,8 +22,8 @@
 						</div>
 						<div class="field {{if .Err_Description}}error{{end}}">
 							<label for="org_description">{{$.i18n.Tr "org.org_desc"}}</label>
-                            <textarea class="autosize" id="org_description" name="org_description" rows="3">{{.Org.Description}}</textarea>
-			                <span class="help">{{.i18n.Tr "available_length"}}: <span id="orgDescLength"></span></span>
+                            <textarea maxlength="255" class="autosize" id="org_description" name="org_description" rows="3">{{.Org.Description}}</textarea>
+			                <span class="help">{{.i18n.Tr "available_length"}}: <span>255</span></span>
 						</div>
 						<div class="field {{if .Err_Website}}error{{end}}">
 							<label for="website">{{.i18n.Tr "org.settings.website"}}</label>

--- a/custom/templates/org/team/new.tmpl
+++ b/custom/templates/org/team/new.tmpl
@@ -20,8 +20,8 @@
 					</div>
 					<div class="field {{if .Err_Description}}error{{end}}">
 						<label for="team_description">{{.i18n.Tr "org.team_desc"}}</label>
-                        <textarea class="autosize" id="team_description" name="team_description" rows="3">{{.Team.Description}}</textarea>
-			            <span class="help">{{.i18n.Tr "available_length"}}: <span id="teamDescLength"></span></span>
+                        <textarea maxlength="255" class="autosize" id="team_description" name="team_description" rows="3">{{.Team.Description}}</textarea>
+			            <span class="help">{{.i18n.Tr "available_length"}}: <span>255</span></span>
 					</div>
 					{{if not (eq .Team.LowerName "owners")}}
 						<div class="grouped field">

--- a/custom/templates/repo/create.tmpl
+++ b/custom/templates/repo/create.tmpl
@@ -59,8 +59,8 @@
 					</div>
 					<div class="inline field {{if .Err_Description}}error{{end}}">
 						<label for="description">{{.i18n.Tr "repo.repo_desc"}}</label>
-						<textarea class="autosize" id="description" name="description" rows="3">{{.description}}</textarea>
-						<span class="help">{{.i18n.Tr "repo.repo_description_length"}}: <span id="descLength"></span></span>
+						<textarea maxlength="512" class="autosize" id="description" name="description" rows="3">{{.description}}</textarea>
+						<span class="help">{{.i18n.Tr "repo.repo_description_length"}}: <span>512</span></span>
 					</div>
 
 					<!-- RCOS Code -->
@@ -71,13 +71,13 @@
 
 					<div class="inline required field">
 						<label for="project_name">{{.i18n.Tr "project_name"}}</label>
-						<textarea required class="autosize" id="project_name" name="project_name" rows="2">{{.project_name}}</textarea>
-						<span class="help">{{.i18n.Tr "available_length"}}: <span id="projectNameLength"></span></span>
+						<textarea maxlength="255" required class="autosize" id="project_name" name="project_name" rows="2">{{.project_name}}</textarea>
+						<span class="help">{{.i18n.Tr "available_length"}}: <span>255</span></span>
 					</div>
 					<div class="inline field">
 						<label for="project_description">{{.i18n.Tr "project_description"}}</label>
-						<textarea class="autosize" id="project_description" name="project_description" rows="3">{{.project_description}}</textarea>
-						<span class="help">{{.i18n.Tr "available_length"}}: <span id="projectDescLength"></span></span>
+						<textarea maxlength="255" class="autosize" id="project_description" name="project_description" rows="3">{{.project_description}}</textarea>
+						<span class="help">{{.i18n.Tr "available_length"}}: <span>255</span></span>
 					</div>
 					<!-- RCOS Code end-->
 

--- a/custom/templates/repo/editor/commit_form.tmpl
+++ b/custom/templates/repo/editor/commit_form.tmpl
@@ -6,8 +6,8 @@
 			<input name="commit_summary" value="{{if .PageIsDelete}}{{.i18n.Tr "repo.editor.delete" .TreePath}}{{else if .PageIsUpload}}{{.i18n.Tr "repo.editor.upload_files_to_dir"}}{{else if and .IsNewFile .IsDmpJson}}{{.i18n.Tr "repo.editor.add_dmp"}}{{else if .IsNewFile}}{{.i18n.Tr "repo.editor.add_tmpl"}}{{else}}{{.i18n.Tr "repo.editor.update" .TreePath}}{{end}}" autofocus>
 		</div>
 		<div class="field">
-			<textarea class="autosize" id="commit_message" name="commit_message" placeholder="{{.i18n.Tr "repo.editor.commit_message_desc"}}" rows="5">{{.commit_message}}</textarea>
-			<span class="help">{{.i18n.Tr "available_length"}}: <span id="commitMessageLength"></span></span>
+			<textarea maxlength="100" class="autosize" id="commit_message" name="commit_message" placeholder="{{.i18n.Tr "repo.editor.commit_message_desc"}}" rows="5">{{.commit_message}}</textarea>
+			<span class="help">{{.i18n.Tr "available_length"}}: <span>100</span></span>
 		</div>
 		<!--Extracted the input needed to commit to the default branch from the comment out.  -->
 		<input type="hidden" name="commit_choice" value="direct">

--- a/custom/templates/repo/issue/comment_tab.tmpl
+++ b/custom/templates/repo/issue/comment_tab.tmpl
@@ -4,9 +4,9 @@
 		<a class="item" data-tab="preview" data-url="{{AppSubURL}}/api/v1/markdown" data-context="{{.RepoLink}}">{{.i18n.Tr "repo.release.preview"}}</a>
 	</div>
 	<div class="ui bottom attached active tab segment" data-tab="write">
-        <textarea id="content" class="autosize" name="content" tabindex="4" data-id="issue-{{.RepoName}}" data-url="{{AppSubURL}}/api/v1/markdown" data-context="{{.Repo.RepoLink}}">
+        <textarea maxlength="3000" id="content" class="autosize" name="content" tabindex="4" data-id="issue-{{.RepoName}}" data-url="{{AppSubURL}}/api/v1/markdown" data-context="{{.Repo.RepoLink}}">
 {{if .IssueTemplate}}{{.IssueTemplate}}{{else if .PullRequestTemplate}}{{.PullRequestTemplate}}{{else}}{{.content}}{{end}}</textarea>
-		<span class="help">{{.i18n.Tr "available_length"}}: <span id="contentLength"></span></span>
+		<span class="help">{{.i18n.Tr "available_length"}}: <span>3000</span></span>
 		
 {{if .IssueTemplate}}{{.IssueTemplate}}{{else if .PullRequestTemplate}}{{.PullRequestTemplate}}{{else}}{{.content}}{{end}}</textarea>
 	</div>

--- a/custom/templates/repo/issue/milestone_new.tmpl
+++ b/custom/templates/repo/issue/milestone_new.tmpl
@@ -30,8 +30,8 @@
 				</div>
 				<div class="field">
 					<label>{{.i18n.Tr "repo.milestones.desc"}}</label>
-                    <textarea class="autosize" id="content" name="content">{{.content}}</textarea>
-			        <span class="help">{{.i18n.Tr "available_length"}}: <span id="contentLength"></span></span>
+                    <textarea maxlength="3000" class="autosize" id="content" name="content">{{.content}}</textarea>
+			        <span class="help">{{.i18n.Tr "available_length"}}: <span>3000</span></span>
 				</div>
 			</div>
 			<div class="four wide column">

--- a/custom/templates/repo/issue/view_content.tmpl
+++ b/custom/templates/repo/issue/view_content.tmpl
@@ -385,6 +385,7 @@
 		</div>
 		<div class="ui bottom attached active write tab segment">
 			<textarea maxlength="3000" tabindex="1" id="content" name="content"></textarea>
+			<span class="help">{{.i18n.Tr "available_length"}}: <span>3000</span></span>
 		</div>
 		<div class="ui bottom attached tab preview segment markdown">
 			{{$.i18n.Tr "repo.release.loading"}}

--- a/custom/templates/repo/issue/view_content.tmpl
+++ b/custom/templates/repo/issue/view_content.tmpl
@@ -212,8 +212,8 @@
 										<div class="commit description field">
 											<div class="ui top">
 												<p>{{$.i18n.Tr "repo.pulls.commit_description"}}:</p>
-												<textarea class="autosize" id="commit_description" name="commit_description" tabindex="4" rows="3"></textarea>
-                                                <span class="help">{{.i18n.Tr "available_length"}}: <span id="commitDescLength"></span></span>
+												<textarea maxlength="100" class="autosize" id="commit_description" name="commit_description" tabindex="4" rows="3"></textarea>
+                                                <span class="help">{{.i18n.Tr "available_length"}}: <span>100</span></span>
 											</div>
 										</div>
 										<button class="ui green button">

--- a/custom/templates/repo/issue/view_content.tmpl
+++ b/custom/templates/repo/issue/view_content.tmpl
@@ -384,7 +384,7 @@
 			<a class="preview item" data-url="{{AppSubURL}}/api/v1/markdown" data-context="{{$.RepoLink}}">{{$.i18n.Tr "repo.release.preview"}}</a>
 		</div>
 		<div class="ui bottom attached active write tab segment">
-			<textarea tabindex="1" id="content" name="content"></textarea>
+			<textarea maxlength="3000" tabindex="1" id="content" name="content"></textarea>
 		</div>
 		<div class="ui bottom attached tab preview segment markdown">
 			{{$.i18n.Tr "repo.release.loading"}}

--- a/custom/templates/repo/release/new.tmpl
+++ b/custom/templates/repo/release/new.tmpl
@@ -46,8 +46,8 @@
 				</div>
 				<div class="field">
 					<label>{{.i18n.Tr "repo.release.content"}}</label>
-                    <textarea class="autosize" id="content" name="content">{{.content}}</textarea>
-			        <span class="help">{{.i18n.Tr "available_length"}}: <span id="contentLength"></span></span>
+                    <textarea maxlength="3000" class="autosize" id="content" name="content">{{.content}}</textarea>
+			        <span class="help">{{.i18n.Tr "available_length"}}: <span>3000</span></span>
 				</div>
 				<div class="field">
 					{{if .attachments}}

--- a/custom/templates/repo/settings/options.tmpl
+++ b/custom/templates/repo/settings/options.tmpl
@@ -19,8 +19,8 @@
 						</div>
 						<div class="field {{if .Err_Description}}error{{end}}">
 							<label for="description">{{$.i18n.Tr "repo.repo_desc"}}</label>
-							<textarea class="autosize" id="description" name="description" rows="3">{{.Repository.Description}}</textarea>
-							<span class="help">{{.i18n.Tr "repo.settings.description_length"}}: <span id="descLength"></span></span>
+							<textarea maxlength="512" class="autosize" id="description" name="description" rows="3">{{.Repository.Description}}</textarea>
+							<span class="help">{{.i18n.Tr "repo.settings.description_length"}}: <span>512</span></span>
 						</div>
 						<div class="field {{if .Err_Website}}error{{end}}">
 							<label for="website">{{.i18n.Tr "repo.settings.site"}}</label>

--- a/custom/templates/repo/settings/project.tmpl
+++ b/custom/templates/repo/settings/project.tmpl
@@ -14,13 +14,13 @@
                         {{.CSRFTokenHTML}}
                         <div class="required field">
                             <label for="project_name">{{.i18n.Tr "project_name"}}</label>
-                            <textarea required class="autosize" id="project_name" name="project_name" rows="2">{{.project_name}}</textarea>
-						    <span class="help">{{.i18n.Tr "available_length"}}: <span id="projectNameLength"></span></span>
+                            <textarea maxlength="255" required class="autosize" id="project_name" name="project_name" rows="2">{{.project_name}}</textarea>
+						    <span class="help">{{.i18n.Tr "available_length"}}: <span>255</span></span>
                         </div>
                         <div class="field">
                             <label for="project_description">{{.i18n.Tr "project_description"}}</label>
-                            <textarea class="autosize" id="project_description" name="project_description" rows="3">{{.project_description}}</textarea>
-                            <span class="help">{{.i18n.Tr "available_length"}}: <span id="projectDescLength"></span></span>
+                            <textarea maxlength="255" class="autosize" id="project_description" name="project_description" rows="3">{{.project_description}}</textarea>
+                            <span class="help">{{.i18n.Tr "available_length"}}: <span>255</span></span>
                         </div>
                         <div class="inline field">
                             <label></label>

--- a/internal/db/org_team.go
+++ b/internal/db/org_team.go
@@ -336,9 +336,11 @@ func UpdateTeam(t *Team, authChanged bool) (err error) {
 		return errors.New("empty team name")
 	}
 
+	/*
 	if len(t.Description) > 255 {
 		t.Description = t.Description[:255]
 	}
+	*/
 
 	sess := x.NewSession()
 	defer sess.Close()

--- a/internal/db/repo.go
+++ b/internal/db/repo.go
@@ -1489,12 +1489,14 @@ func GetNonMirrorRepositories() ([]*Repository, error) {
 func updateRepository(e Engine, repo *Repository, visibilityChanged bool) (err error) {
 	repo.LowerName = strings.ToLower(repo.Name)
 
+	/*
 	if len(repo.Description) > 512 {
 		repo.Description = repo.Description[:512]
 	}
 	if len(repo.Website) > 255 {
 		repo.Website = repo.Website[:255]
 	}
+	*/
 
 	if _, err = e.ID(repo.ID).AllCols().Update(repo); err != nil {
 		return fmt.Errorf("update: %v", err)

--- a/internal/db/user.go
+++ b/internal/db/user.go
@@ -752,7 +752,7 @@ func updateUser(e Engine, u *User) error {
 
 	u.LowerName = strings.ToLower(u.Name)
 	u.Website = tool.TruncateString(u.Website, 255)
-	u.Description = tool.TruncateString(u.Description, 255)
+	//u.Description = tool.TruncateString(u.Description, 255)
 
 	_, err := e.ID(u.ID).AllCols().Update(u)
 	return err

--- a/internal/form/org.go
+++ b/internal/form/org.go
@@ -20,7 +20,7 @@ func (f *CreateOrg) Validate(ctx *macaron.Context, errs binding.Errors) binding.
 type UpdateOrgSetting struct {
 	Name            string `binding:"Required;AlphaDashDot;MaxSize(35)" locale:"org.org_name_holder"`
 	FullName        string `binding:"MaxSize(100)"`
-	OrgDescription     string `binding:"MaxSize(255)"`
+	OrgDescription     string 
 	Website         string `binding:"Url;MaxSize(100)"`
 	Location        string `binding:"MaxSize(50)"`
 	MaxRepoCreation int
@@ -32,7 +32,7 @@ func (f *UpdateOrgSetting) Validate(ctx *macaron.Context, errs binding.Errors) b
 
 type CreateTeam struct {
 	TeamName    string `binding:"Required;AlphaDashDot;MaxSize(30)"`
-	TeamDescription string `binding:"MaxSize(255)"`
+	TeamDescription string
 	Permission  string
 }
 

--- a/internal/form/repo.go
+++ b/internal/form/repo.go
@@ -27,13 +27,13 @@ type CreateRepo struct {
 	RepoName           string `binding:"Required;AlphaDashDot;MaxSize(100)"`
 	Private            bool
 	Unlisted           bool
-	Description        string `binding:"MaxSize(512)"`
+	Description        string
 	AutoInit           bool
 	Gitignores         string
 	License            string
 	Readme             string
-	ProjectName        string `binding:"Required;MaxSize(255)"`
-	ProjectDescription string `binding:"MaxSize(255)"`
+	ProjectName        string
+	ProjectDescription string
 }
 
 func (f *CreateRepo) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
@@ -90,7 +90,7 @@ func (f MigrateRepo) ParseRemoteAddr(user *db.User) (string, error) {
 
 type RepoSetting struct {
 	RepoName      string `binding:"Required;AlphaDashDot;MaxSize(100)"`
-	Description   string `binding:"MaxSize(512)"`
+	Description   string
 	Website       string `binding:"Url;MaxSize(100)"`
 	Branch        string
 	Interval      int
@@ -431,8 +431,8 @@ func (f *DeleteRepoFile) IsNewBrnach() bool {
 Research Project From
 **/
 type ResearchProtect struct {
-	ProjectName        string `binding:"Required;MaxSize(255)"`
-	ProjectDescription string `binding:"MaxSize(255)"`
+	ProjectName        string `binding:"Required"`
+	ProjectDescription string
 }
 
 func (f *ResearchProtect) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {

--- a/internal/route/org/setting.go
+++ b/internal/route/org/setting.go
@@ -71,7 +71,7 @@ func SettingsPost(c *context.Context, f form.UpdateOrgSetting) {
 	}
 
 	org.FullName = f.FullName
-	org.Description = f.OrgDescription
+	org.Description = strings.ReplaceAll(f.OrgDescription, "\r\n", "\n")
 	org.Website = f.Website
 	org.Location = f.Location
 	if err := db.UpdateUser(org); err != nil {

--- a/internal/route/org/teams.go
+++ b/internal/route/org/teams.go
@@ -7,6 +7,7 @@ package org
 import (
 	"net/http"
 	"path"
+	"strings"
 
 	"github.com/unknwon/com"
 	log "unknwon.dev/clog/v2"
@@ -157,7 +158,7 @@ func NewTeamPost(c *context.Context, f form.CreateTeam) {
 	t := &db.Team{
 		OrgID:       c.Org.Organization.ID,
 		Name:        f.TeamName,
-		Description: f.TeamDescription,
+		Description: strings.ReplaceAll(f.TeamDescription, "\r\n", "\n"),
 		Authorize:   db.ParseAccessMode(f.Permission),
 	}
 	c.Data["Team"] = t
@@ -244,7 +245,7 @@ func EditTeamPost(c *context.Context, f form.CreateTeam) {
 			t.Authorize = auth
 		}
 	}
-	t.Description = f.TeamDescription
+	t.Description = strings.ReplaceAll(f.TeamDescription, "\r\n", "\n")
 	if err := db.UpdateTeam(t, isAuthChanged); err != nil {
 		c.Data["Err_TeamName"] = true
 		switch {

--- a/internal/route/repo/issue.go
+++ b/internal/route/repo/issue.go
@@ -431,7 +431,7 @@ func NewIssuePost(c *context.Context, f form.NewIssue) {
 		Poster:      c.User,
 		MilestoneID: milestoneID,
 		AssigneeID:  assigneeID,
-		Content:     f.Content,
+		Content:  strings.ReplaceAll(f.Content, "\r\n", "\n"),
 	}
 	if err := db.NewIssue(c.Repo.Repository, issue, labelIDs, attachments); err != nil {
 		c.Error(err, "new issue")
@@ -906,8 +906,8 @@ func NewComment(c *context.Context, f form.CreateComment) {
 	if len(f.Content) == 0 && len(attachments) == 0 {
 		return
 	}
-
-	comment, err = db.CreateIssueComment(c.User, c.Repo.Repository, issue, f.Content, attachments)
+	content := strings.ReplaceAll(f.Content, "\r\n", "\n")
+	comment, err = db.CreateIssueComment(c.User, c.Repo.Repository, issue, content, attachments)
 	if err != nil {
 		c.Error(err, "create issue comment")
 		return
@@ -1140,7 +1140,7 @@ func NewMilestonePost(c *context.Context, f form.CreateMilestone) {
 	if err = db.NewMilestone(&db.Milestone{
 		RepoID:   c.Repo.Repository.ID,
 		Name:     f.Title,
-		Content:  f.Content,
+		Content:  strings.ReplaceAll(f.Content, "\r\n", "\n"),
 		Deadline: deadline,
 	}); err != nil {
 		c.Error(err, "new milestone")
@@ -1199,7 +1199,7 @@ func EditMilestonePost(c *context.Context, f form.CreateMilestone) {
 		return
 	}
 	m.Name = f.Title
-	m.Content = f.Content
+	m.Content = strings.ReplaceAll(f.Content, "\r\n", "\n")
 	m.Deadline = deadline
 	if err = db.UpdateMilestone(m); err != nil {
 		c.Error(err, "update milestone")

--- a/internal/route/repo/repo.go
+++ b/internal/route/repo/repo.go
@@ -135,15 +135,15 @@ func CreatePost(c *context.Context, f form.CreateRepo) {
 	
 	repo, err := db.CreateRepository(c.User, ctxUser, db.CreateRepoOptions{
 		Name:               f.RepoName,
-		Description:        f.Description,
+		Description:        strings.ReplaceAll(f.Description, "\r\n", "\n"),
 		Gitignores:         "",
 		License:            "",
 		Readme:             "Default",
 		IsPrivate:          f.Private || conf.Repository.ForcePrivate,
 		IsUnlisted:         f.Unlisted,
 		AutoInit:           true,
-		ProjectName:        f.ProjectName,
-		ProjectDescription: f.ProjectDescription,
+		ProjectName:        strings.ReplaceAll(f.ProjectName, "\r\n", "\n"),
+		ProjectDescription: strings.ReplaceAll(f.ProjectDescription, "\r\n", "\n"),
 	})
 	if err == nil {
 		log.Trace("Repository created [%d]: %s/%s", repo.ID, ctxUser.Name, repo.Name)

--- a/internal/route/repo/repo.go
+++ b/internal/route/repo/repo.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"unicode"
 
 	"github.com/unknwon/com"
 	log "unknwon.dev/clog/v2"
@@ -119,6 +120,19 @@ func CreatePost(c *context.Context, f form.CreateRepo) {
 		return
 	}
 
+	// velidate Research Project Name
+	projectname_has_char := false
+	for _, char := range f.ProjectName {
+		if unicode.IsLetter(char) || unicode.Is(unicode.Hiragana, char) || unicode.Is(unicode.Katakana, char) || unicode.Is(unicode.Han, char) {
+			projectname_has_char = true
+		}
+
+	}
+	if projectname_has_char == false{
+		c.RenderWithErr(c.Tr("form.projectname_has_no_char"), CREATE, &f)
+		return
+	}
+	
 	repo, err := db.CreateRepository(c.User, ctxUser, db.CreateRepoOptions{
 		Name:               f.RepoName,
 		Description:        f.Description,

--- a/internal/route/repo/setting.go
+++ b/internal/route/repo/setting.go
@@ -82,7 +82,7 @@ func SettingsPost(c *context.Context, f form.RepoSetting) {
 		repo.Name = newRepoName
 		repo.LowerName = strings.ToLower(newRepoName)
 
-		repo.Description = f.Description
+		repo.Description = strings.ReplaceAll(f.Description, "\r\n", "\n")
 		repo.Website = f.Website
 
 		// Visibility of forked repository is forced sync with base repository.
@@ -760,8 +760,8 @@ func SettingsProtectePost(c *context.Context, f form.ResearchProtect) {
 		return
 	}
 
-	repo.ProtectName = f.ProjectName
-	repo.ProjectDescription = f.ProjectDescription
+	repo.ProtectName = strings.ReplaceAll(f.ProjectName, "\r\n", "\n")
+	repo.ProjectDescription = strings.ReplaceAll(f.ProjectDescription, "\r\n", "\n")
 
 	if err := db.UpdateRepository(repo, false); err != nil {
 		c.Error(err, "update repository")

--- a/internal/route/repo/setting.go
+++ b/internal/route/repo/setting.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/gogs/git-module"
 	"github.com/unknwon/com"
@@ -745,6 +746,19 @@ func SettingsProtectePost(c *context.Context, f form.ResearchProtect) {
 	c.Data["PageIsSettingsProject"] = true
 
 	repo := c.Repo.Repository
+
+	// velidate Research Project Name
+	projectname_has_char := false
+	for _, char := range f.ProjectName {
+		if unicode.IsLetter(char) || unicode.Is(unicode.Hiragana, char) || unicode.Is(unicode.Katakana, char) || unicode.Is(unicode.Han, char) {
+			projectname_has_char = true
+		}
+
+	}
+	if projectname_has_char == false{
+		c.RenderWithErr(c.Tr("form.projectname_has_no_char"), SETTINGS_PROJECT, &f)
+		return
+	}
 
 	repo.ProtectName = f.ProjectName
 	repo.ProjectDescription = f.ProjectDescription

--- a/public/js/gogs.js
+++ b/public/js/gogs.js
@@ -1639,44 +1639,6 @@ $(document).ready(function() {
     );
   });
 
-  /*
-  // Autosize
-  if ($("#description.autosize").length > 0) {
-    autosize($("#description"));
-    showMessageMaxLength(512, "description", "descLength");
-  }
-  if ($("#project_name.autosize").length > 0) {
-    autosize($("#project_name"));
-    showMessageMaxLength(255, "project_name", "projectNameLength");
-  }
-  if ($("#project_description.autosize").length > 0) {
-    autosize($("#project_description"));
-    showMessageMaxLength(255, "project_description", "projectDescLength");
-  }
-  if ($("#commit_message.autosize").length > 0) {
-    autosize($("#commit_message"));
-    showMessageMaxLength(100, "commit_message", "commitMessageLength");
-  }
-  if ($("#content.autosize").length > 0) {
-    autosize($("#content"));
-    showMessageMaxLength(3000, "content", "contentLength");
-  }
-  if ($("#team_description.autosize").length > 0) {
-    autosize($("#team_description"));
-    showMessageMaxLength(255, "team_description", "teamDescLength");
-  }
-  if ($("#org_description.autosize").length > 0) {
-    autosize($("#org_description"));
-    showMessageMaxLength(255, "org_description", "orgDescLength");
-  }
-  if ($("#commit_description.autosize").length > 0) {
-    autosize($("#commit_description"));
-    showMessageMaxLength(100, "commit_description", "commitDescLength");
-  }
-  */
-  
-
-
   // AJAX load buttons
   $(".ajax-load-button").click(function() {
     var $this = $(this);
@@ -1905,45 +1867,6 @@ function getByteLen(normalVal) {
   }
   return byteLen;
 }
-
-/*
-function showMessageMaxLength(maxLen, textElemId, counterId) {
-
-  var $msg = $("#" + textElemId);
-  $("#" + counterId).html(maxLen - getByteLen($msg.val()));
-  console.log("TEST")
-  var $msg = $(this);
-  var text = $msg.val();
-  console.log(text)
-  if (text === "\n" || text === "\r" || text === "\r\n") { // 入力が改行だけの場合
-    return false;
-  }
-  
-  var onMessageKey = function(e) {
-    console.log("TEST")
-    var $msg = $(this);
-    var text = $msg.val();
-    //var len = getByteLen(text);
-    //var remainder = maxLen - len;
-    console.log($text)
-    if (text === "\n" || text === "\r" || text === "\r\n") { // 入力が改行だけの場合
-      return false;
-    }
-    
-    if (len >= maxLen) {
-      $msg.val($msg.val().substr(0, maxLen));
-      remainder = 0;
-    }
-    
-
-    $("#" + counterId).html(maxLen);
-    
-  };
-  
-
-  //$msg.keyup(onMessageKey).keydown(onMessageKey);
-}
-*/
 
 // GIN specific code
 function OdmlEditor() {

--- a/public/js/gogs.js
+++ b/public/js/gogs.js
@@ -1639,6 +1639,7 @@ $(document).ready(function() {
     );
   });
 
+  /*
   // Autosize
   if ($("#description.autosize").length > 0) {
     autosize($("#description"));
@@ -1672,6 +1673,8 @@ $(document).ready(function() {
     autosize($("#commit_description"));
     showMessageMaxLength(100, "commit_description", "commitDescLength");
   }
+  */
+  
 
 
   // AJAX load buttons
@@ -1903,26 +1906,44 @@ function getByteLen(normalVal) {
   return byteLen;
 }
 
+/*
 function showMessageMaxLength(maxLen, textElemId, counterId) {
+
   var $msg = $("#" + textElemId);
   $("#" + counterId).html(maxLen - getByteLen($msg.val()));
-
+  console.log("TEST")
+  var $msg = $(this);
+  var text = $msg.val();
+  console.log(text)
+  if (text === "\n" || text === "\r" || text === "\r\n") { // 入力が改行だけの場合
+    return false;
+  }
+  
   var onMessageKey = function(e) {
+    console.log("TEST")
     var $msg = $(this);
     var text = $msg.val();
-    var len = getByteLen(text);
-    var remainder = maxLen - len;
-
+    //var len = getByteLen(text);
+    //var remainder = maxLen - len;
+    console.log($text)
+    if (text === "\n" || text === "\r" || text === "\r\n") { // 入力が改行だけの場合
+      return false;
+    }
+    
     if (len >= maxLen) {
       $msg.val($msg.val().substr(0, maxLen));
       remainder = 0;
     }
+    
 
-    $("#" + counterId).html(remainder);
+    $("#" + counterId).html(maxLen);
+    
   };
+  
 
-  $msg.keyup(onMessageKey).keydown(onMessageKey);
+  //$msg.keyup(onMessageKey).keydown(onMessageKey);
 }
+*/
 
 // GIN specific code
 function OdmlEditor() {


### PR DESCRIPTION
# PULL REQUEST

## Background

* ユーザビリティ指摘事項44

## Main Points of Modification

* バイト数ではなく、文字数で上限値を設定＋制限する。
* 入力可能バイト数のカウントの削除（全角非対応のため）
* 2文字の改行コードを1文字の改行コードに置換する
* 最大文字数の制限はフォーム構造体ではなく、htmlのmaxlengthでする。
* プロジェクト名はスペース・改行だけが入力された場合は、検証でエラーを返す。

## Test

* ローカル環境でテスト済み
  * 課題更新フォームの最大文字数表示漏れ・maxlength定義漏れは修正後、再テスト。

## Viewpoint for Review

* 上限文字数以上の入力ができないこと。

## Supplementary Information

* リポジトリトップ画面のリポジトリ説明の表示など、入力フォームの値をhtmlで表示している箇所がある。そのようなプレビュー画面では、テンプレート側の仕様で、連続する半角スペースや改行が1つにまとめられるようになっている。ただし、設定画面では、入力した値と差分なく表示される。

## ToDo

*