### PR TITLE
remove_dataset

### DIFF
--- a/custom/templates/explore/navbar.tmpl
+++ b/custom/templates/explore/navbar.tmpl
@@ -4,9 +4,11 @@
 		<a class="{{if .PageIsExploreRepositories}}active{{end}} item" href="{{AppSubURL}}/explore/repos">
 			<span class="octicon octicon-repo"></span> {{.i18n.Tr "explore.repos"}}
 		</a>
+		<!--
 		<a class="item" href="https://doid.gin.g-node.org">
 			<span class="octicon octicon-mortar-board"></span> {{.i18n.Tr "gindoi"}}
 		</a>
+		-->
 		<a class="{{if .PageIsExploreData}}active{{end}} item" href="{{AppSubURL}}/explore/data">
 			<span class="octicon octicon-file"></span> {{.i18n.Tr "explore.data"}}
 		</a>


### PR DESCRIPTION
# PULL REQUEST

## Background

* エクスプローラのregistered datasetsが外部へのリンクになっている

## Main Points of Modification

* リンクの部分をコメントアウトした

## Test

* ローカル環境でregistered datasets欄が消えたことを確認

キャプチャ(追記)
![スクリーンショット 2023-06-12 151242](https://github.com/NII-DG/gogs/assets/108637920/bd9bb2e0-3cbd-403c-b140-5ddabf0c8e36)

## Viewpoint for Review

*

## Supplementary Information

*

## ToDo

*