### PR TITLE
Feature/fix explorer provisional

### DIFF
--- a/internal/route/home.go
+++ b/internal/route/home.go
@@ -53,7 +53,6 @@ func Home(c *context.Context) {
 }
 
 func ExploreRepos(c *context.Context) {
-	fmt.Println("ExploreRepos")
 	c.Data["Title"] = c.Tr("explore")
 	c.Data["PageIsExplore"] = true
 	c.Data["PageIsExploreRepositories"] = true
@@ -299,7 +298,6 @@ func RenderUserSearch(c *context.Context, opts *UserSearchOptions) {
 }
 
 func ExploreUsers(c *context.Context) {
-	fmt.Println("ExploreUsers")
 	c.Data["Title"] = c.Tr("explore")
 	c.Data["PageIsExplore"] = true
 	c.Data["PageIsExploreUsers"] = true
@@ -324,7 +322,6 @@ func ExploreUsers(c *context.Context) {
 }
 
 func ExploreOrganizations(c *context.Context) {
-	fmt.Println("ExploreOrganizations")
 	c.Data["Title"] = c.Tr("explore")
 	c.Data["PageIsExplore"] = true
 	c.Data["PageIsExploreOrganizations"] = true

--- a/internal/route/routes_gin.go
+++ b/internal/route/routes_gin.go
@@ -16,19 +16,8 @@ func filterUnlistedRepos(repos []*db.Repository) []*db.Repository {
 func filterRepos(userID int64, repos []*db.Repository) []*db.Repository {
 	var showRep []*db.Repository
 	for _, repo := range repos {
-		if repo.Owner.IsOrganization() {
-			if repo.Owner.IsOrgMember(userID) {
-				showRep = append(showRep, repo)
-			}
-		} else {
-			// make repo private temporary
-			tmpIsPrivate := repo.IsPrivate
-			repo.IsPrivate = true
-			// Authorize
-			if db.Perms.Authorize(userID, repo, db.AccessModeRead) {
-				repo.IsPrivate = tmpIsPrivate
-				showRep = append(showRep, repo)
-			}
+		if repo.OwnerID == userID {
+			showRep = append(showRep, repo)
 		}
 	}
 	return showRep
@@ -37,14 +26,36 @@ func filterRepos(userID int64, repos []*db.Repository) []*db.Repository {
 func filterUsers(userID int64, users []*db.User) []*db.User {
 	var showUser []*db.User
 	for _, user := range users {
+		// 組織の場合、自分が所属していれば表示する
 		if user.IsOrganization() {
-			// show only belonging organization
 			if user.IsOrgMember(userID) {
 				showUser = append(showUser, user)
 			}
-		} else {
-			// show only user itself
-			if user.ID == userID {
+		} else { // ユーザーの場合
+			isShow := map[int64]bool{}
+			isShow[userID] = true
+
+			repos, _ := db.GetUserAndCollaborativeRepositories(userID)
+			for _, repo := range repos {
+				// 自分が所有するリポジトリの共同編集者は表示する
+				if repo.OwnerID == userID {
+					collaborators, _ := repo.GetCollaborators()
+					for _, collaborator := range collaborators {
+						isShow[collaborator.User.ID] = true
+					}
+				} else { // 自分が共同編集しているリポジトリの所有者は表示する
+					isShow[repo.OwnerID] = true
+				}
+			}
+
+			// 自分と同じ組織に所属しているユーザーは表示する
+			orgs, _ := db.GetOrgsByUserID(userID, true)
+			for _, org := range orgs {
+				if org.IsOrgMember(user.ID) {
+					isShow[user.ID] = true
+				}
+			}
+			if isShow[user.ID] == true {
 				showUser = append(showUser, user)
 			}
 		}

--- a/internal/route/routes_gin.go
+++ b/internal/route/routes_gin.go
@@ -13,6 +13,7 @@ func filterUnlistedRepos(repos []*db.Repository) []*db.Repository {
 	return showRep
 }
 
+// 自分の所有しているリポジトリのみ表示する
 func filterRepos(userID int64, repos []*db.Repository) []*db.Repository {
 	var showRep []*db.Repository
 	for _, repo := range repos {

--- a/internal/route/routes_gin.go
+++ b/internal/route/routes_gin.go
@@ -12,3 +12,42 @@ func filterUnlistedRepos(repos []*db.Repository) []*db.Repository {
 	}
 	return showRep
 }
+
+func filterRepos(userID int64, repos []*db.Repository) []*db.Repository {
+	var showRep []*db.Repository
+	for _, repo := range repos {
+		if repo.Owner.IsOrganization() {
+			if repo.Owner.IsOrgMember(userID) {
+				showRep = append(showRep, repo)
+			}
+		} else {
+			// make repo private temporary
+			tmpIsPrivate := repo.IsPrivate
+			repo.IsPrivate = true
+			// Authorize
+			if db.Perms.Authorize(userID, repo, db.AccessModeRead) {
+				repo.IsPrivate = tmpIsPrivate
+				showRep = append(showRep, repo)
+			}
+		}
+	}
+	return showRep
+}
+
+func filterUsers(userID int64, users []*db.User) []*db.User {
+	var showUser []*db.User
+	for _, user := range users {
+		if user.IsOrganization() {
+			// show only belonging organization
+			if user.IsOrgMember(userID) {
+				showUser = append(showUser, user)
+			}
+		} else {
+			// show only user itself
+			if user.ID == userID {
+				showUser = append(showUser, user)
+			}
+		}
+	}
+	return showUser
+}


### PR DESCRIPTION
# PULL REQUEST

## Background

* エクスプローラ画面の暫定対処

## Main Points of Modification

* 「ユーザー」で自分自身、共同編集者、組織に所属するユーザー以外は表示させないようにする
* 「リポジトリ」で公開非公開に関わらず自分自身が作成したリポジトリしか表示させないようにする
* 「組織」では自分が所属する組織のみを表示する
* ログインしていないユーザーはどのリポジトリも見えないようにする
## キャプチャ

- (前提)緑アイコンのユーザーのリポジトリの共同編集者が茶色アイコンのユーザー
![スクリーンショット 2023-06-14 175944](https://github.com/NII-DG/gogs/assets/108637920/523c684e-5cde-4a22-b79c-52f04724d957)

-  (前提)緑アイコンとピンクアイコンのユーザーが同じ組織に所属
![スクリーンショット 2023-06-14 175738](https://github.com/NII-DG/gogs/assets/108637920/67535d5b-150b-4f30-9b48-c2879297f5df)

- ピンクアイコンのユーザーからは茶色アイコンのユーザーが見えない
![スクリーンショット 2023-06-14 180020](https://github.com/NII-DG/gogs/assets/108637920/78df456a-c376-4cb5-9d69-f630feec19e9)

- 茶色アイコンのユーザーからはピンクアイコンのユーザーが見えない
![スクリーンショット 2023-06-14 180140](https://github.com/NII-DG/gogs/assets/108637920/7d56a316-aa45-4cc6-9f6f-f4a9132fd492)

- 緑アイコンのユーザーからは茶色、ピンクアイコンのユーザーが見える
![スクリーンショット 2023-06-14 182814](https://github.com/NII-DG/gogs/assets/108637920/52122cc8-4976-4524-97d7-eba1c0f619c4)

- 自分の作成したリポジトリのみ見える
![スクリーンショット 2023-06-14 180218](https://github.com/NII-DG/gogs/assets/108637920/83f92ed4-7399-4c3e-87d2-eea63618ff4b)

- サインインしていないユーザーからはどのリポジトリも見えない
![スクリーンショット 2023-06-14 180715](https://github.com/NII-DG/gogs/assets/108637920/9b8102f1-1d88-4798-8c8b-56f658e26b92)