### PR TITLE
所属組織が空だった場合のエラー文を修正

### DIFF
--- a/custom/conf/locale/locale_en-US.ini
+++ b/custom/conf/locale/locale_en-US.ini
@@ -239,6 +239,7 @@ TreeName = File path
 Content = Content
 
 require_error = ` cannot be empty.`
+AffiliationId = Affiliation
 alpha_dash_error = ` must be alphanumeric or dash(-_) characters.`
 alpha_dash_dot_error = ` must be alphanumeric or dash(-_) or dot characters.`
 alpha_dash_dot_slash_error = ` must be alphanumeric, dash (-_), dot or slash characters.`

--- a/custom/conf/locale/locale_ja-JP.ini
+++ b/custom/conf/locale/locale_ja-JP.ini
@@ -238,7 +238,8 @@ CommitChoice=コミットを選択
 TreeName=ファイルのパス
 Content=コンテンツ
 
-require_error=空にできません
+require_error=は空にできません
+AffiliationId=所属組織
 alpha_dash_error=アルファベット、数字、ハイフン"-"、アンダースコア"_"のいずれかの必要があります
 alpha_dash_dot_error=' アルファベット、数値、ハイフン(-)、アンダースコア(_) 、ドット(.) のいずれかを入力する必要があります。 '
 alpha_dash_dot_slash_error=` アルファベット、数字、ハイフン(-)、アンダースコア(_)、ドット(.)、スラッシュ(/) のみ利用できます。`

--- a/custom/conf/locale/locale_ja-JP.ini
+++ b/custom/conf/locale/locale_ja-JP.ini
@@ -238,7 +238,7 @@ CommitChoice=コミットを選択
 TreeName=ファイルのパス
 Content=コンテンツ
 
-require_error=は空にできません
+require_error=は必須項目です
 AffiliationId=所属組織
 alpha_dash_error=アルファベット、数字、ハイフン"-"、アンダースコア"_"のいずれかの必要があります
 alpha_dash_dot_error=' アルファベット、数値、ハイフン(-)、アンダースコア(_) 、ドット(.) のいずれかを入力する必要があります。 '


### PR DESCRIPTION
# PULL REQUEST

## Background

* https://ivis.backlog.com/view/NII_DG-193

## Main Points of Modification

* 所属組織を選択せずに、アカウントを作成しようとした場合のエラー文を修正した。
* ![image](https://github.com/NII-DG/gogs/assets/91708725/54005707-957e-47e0-88bf-b85b4d0ae2c7)
* ![image](https://github.com/NII-DG/gogs/assets/91708725/51867697-ac67-4efa-aad2-25b742a66c78)


## Test

* ローカルでテスト済。

## Viewpoint for Review

*

## Supplementary Information

*

## ToDo

*