### PR TITLE
組織Webhookの無効化

### DIFF
--- a/custom/templates/org/settings/navbar.tmpl
+++ b/custom/templates/org/settings/navbar.tmpl
@@ -1,0 +1,15 @@
+<div class="four wide column">
+	<div class="ui vertical menu">
+		<div class="header item">{{.i18n.Tr "org.settings"}}</div>
+		<a class="{{if .PageIsSettingsOptions}}active{{end}} item" href="{{.OrgLink}}/settings">
+			{{.i18n.Tr "org.settings.options"}}
+		</a>
+		<!-- Hiding "Hooks" from the side menu of the Org settings screen. by RCOS -->
+		<!-- <a class="{{if .PageIsSettingsHooks}}active{{end}} item" href="{{.OrgLink}}/settings/hooks">
+			{{.i18n.Tr "repo.settings.hooks"}}
+		</a> -->
+		<a class="{{if .PageIsSettingsDelete}}active{{end}} item" href="{{.OrgLink}}/settings/delete">
+			{{.i18n.Tr "org.settings.delete"}}
+		</a>
+	</div>
+</div>

--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -354,22 +354,23 @@ func runWeb(c *cli.Context) error {
 		reqRepoAdmin := context.RequireRepoAdmin()
 		reqRepoWriter := context.RequireRepoWriter()
 
-		webhookRoutes := func() {
-			m.Group("", func() {
-				m.Get("", repo.Webhooks)
-				m.Post("/delete", repo.DeleteWebhook)
-				m.Get("/:type/new", repo.WebhooksNew)
-				m.Post("/gogs/new", bindIgnErr(form.NewWebhook{}), repo.WebhooksNewPost)
-				m.Post("/slack/new", bindIgnErr(form.NewSlackHook{}), repo.WebhooksSlackNewPost)
-				m.Post("/discord/new", bindIgnErr(form.NewDiscordHook{}), repo.WebhooksDiscordNewPost)
-				m.Post("/dingtalk/new", bindIgnErr(form.NewDingtalkHook{}), repo.WebhooksDingtalkNewPost)
-				m.Get("/:id", repo.WebhooksEdit)
-				m.Post("/gogs/:id", bindIgnErr(form.NewWebhook{}), repo.WebhooksEditPost)
-				m.Post("/slack/:id", bindIgnErr(form.NewSlackHook{}), repo.WebhooksSlackEditPost)
-				m.Post("/discord/:id", bindIgnErr(form.NewDiscordHook{}), repo.WebhooksDiscordEditPost)
-				m.Post("/dingtalk/:id", bindIgnErr(form.NewDingtalkHook{}), repo.WebhooksDingtalkEditPost)
-			}, repo.InjectOrgRepoContext())
-		}
+		// Disable route to hooks settings in settings by RCOS
+		// webhookRoutes := func() {
+		// 	m.Group("", func() {
+		// 		m.Get("", repo.Webhooks)
+		// 		m.Post("/delete", repo.DeleteWebhook)
+		// 		m.Get("/:type/new", repo.WebhooksNew)
+		// 		m.Post("/gogs/new", bindIgnErr(form.NewWebhook{}), repo.WebhooksNewPost)
+		// 		m.Post("/slack/new", bindIgnErr(form.NewSlackHook{}), repo.WebhooksSlackNewPost)
+		// 		m.Post("/discord/new", bindIgnErr(form.NewDiscordHook{}), repo.WebhooksDiscordNewPost)
+		// 		m.Post("/dingtalk/new", bindIgnErr(form.NewDingtalkHook{}), repo.WebhooksDingtalkNewPost)
+		// 		m.Get("/:id", repo.WebhooksEdit)
+		// 		m.Post("/gogs/:id", bindIgnErr(form.NewWebhook{}), repo.WebhooksEditPost)
+		// 		m.Post("/slack/:id", bindIgnErr(form.NewSlackHook{}), repo.WebhooksSlackEditPost)
+		// 		m.Post("/discord/:id", bindIgnErr(form.NewDiscordHook{}), repo.WebhooksDiscordEditPost)
+		// 		m.Post("/dingtalk/:id", bindIgnErr(form.NewDingtalkHook{}), repo.WebhooksDingtalkEditPost)
+		// 	}, repo.InjectOrgRepoContext())
+		// }
 
 		// ***** START: Organization *****
 		m.Group("/org", func() {
@@ -413,7 +414,8 @@ func runWeb(c *cli.Context) error {
 						Post(bindIgnErr(form.UpdateOrgSetting{}), org.SettingsPost)
 					m.Post("/avatar", binding.MultipartForm(form.Avatar{}), org.SettingsAvatar)
 					m.Post("/avatar/delete", org.SettingsDeleteAvatar)
-					m.Group("/hooks", webhookRoutes)
+					// Disable route to hooks settings in Org settings by RCOS
+					// m.Group("/hooks", webhookRoutes)
 					m.Route("/delete", "GET,POST", org.SettingsDelete)
 				})
 


### PR DESCRIPTION
# PULL REQUEST

## Background

* 不要な組織WebhookがUI上に表示されていた。
![image](https://github.com/NII-DG/gogs/assets/96706614/3e1fa99e-ca76-4895-a431-7c6884c7f3de)


## Main Points of Modification

* 不要な組織Webhookの非表示化
* 組織のhooks　ルートの無効化

## Test

ローカルにGIN-forkをデプロイしてUI上で確認した。

* 不要な組織Webhookの非表示化
![image](https://github.com/NII-DG/gogs/assets/96706614/59f0d21f-04fa-4cdc-8b59-54c898c94be7)
* 組織のhooks　ルートの無効化
![image](https://github.com/NII-DG/gogs/assets/96706614/2230e64e-6197-4177-a4da-945f974aa8ad)
