### PR TITLE
launchbinderボタンの説明文の修正

### DIFF
--- a/custom/conf/locale/locale_en-US.ini
+++ b/custom/conf/locale/locale_en-US.ini
@@ -426,6 +426,7 @@ delete_account_title = Account Deletion
 delete_account_desc = This account is going to be deleted permanently, do you want to continue?
 
 [repo]
+launch_binder = Establish and access a research execution environment.
 owner = Owner
 repo_name = Repository Name
 repo_name_helper = Will be used to define the URL (path) of the repository. It must be one word (no spaces) and can contain letters (a-z, A-Z), numbers (0-9), dash (-), underscore (_), or dot (.) characters. Repository names should be short, unique and specific (do not use a generic name like "dataset", "plos_paper", etc).

--- a/custom/conf/locale/locale_ja-JP.ini
+++ b/custom/conf/locale/locale_ja-JP.ini
@@ -424,6 +424,7 @@ delete_account_title=アカウントの削除
 delete_account_desc=このアカウントは完全に削除されます。 本当によろしいですか？
 
 [repo]
+launch_binder = 研究実行環境を構築し、アクセスします。
 web_content_explanation = このファイルのコンテンツは、当サービス外部のインターネット上(Amason S3など)にあります。
 web_content_warning = 以下のリンクをクリックすると外部にあるコンテンツにアクセスできますが、安全性は保障できません。
 other_repository_content_explanation = このファイルのコンテンツはGIN-forkの他のリポジトリにあります。

--- a/custom/templates/repo/header_gin.tmpl
+++ b/custom/templates/repo/header_gin.tmpl
@@ -10,7 +10,7 @@
 								{{if $.HasDmpJson }}
 									{{ if $.HasMaDmp }}
 										<a class="ui basic button" href="{{$.RepoLink}}/src/{{EscapePound $.BranchName}}/maDMP.ipynb" data-position="bottom center"><i class="octicon octicon-file"></i>View maDMP</a>
-										<div class="ui labeled button" data-tooltip="Transition to the maDMP execution environment. Please click this after 'Generate maDMP'" data-position="bottom center">
+										<div class="ui labeled button" data-tooltip={{.i18n.Tr "repo.launch_binder"}} data-position="bottom center">
 										<button class="ui basic button" data-position="bottom center">
 											<a href="https://binder.cs.rcos.nii.ac.jp/v2/git/{{.ginURL}}%2F{{.Owner.Name}}%2F{{.Repository.Name}}.git/master?filepath=maDMP.ipynb" target="_blank" rel="noopener">
 												<img src="https://binder.cs.rcos.nii.ac.jp/badge_logo.svg">


### PR DESCRIPTION
# PULL REQUEST

## Background

* https://ivis.backlog.com/view/NII_DG-227

## Main Points of Modification

* launch binderボタンの説明文を修正した。
* 説明文は、ポータルサイトのマニュアルに合わせて、「研究実行環境を構築し、アクセスします。」とした。
![image](https://github.com/NII-DG/gogs/assets/91708725/6ef663cd-21b3-414d-9118-1e34b1f9dc5a)

## Test

* ローカル環境で修正を確認した。
![image](https://github.com/NII-DG/gogs/assets/91708725/99d5ba3f-ba95-48f3-a981-4ea99fbbe5a1)

## Viewpoint for Review

* 説明文の適切さ。

## Supplementary Information

* 英語、日本語で説明文を設定している。

## ToDo

* なし。