### PR TITLE
ユーザフォロー一覧のフォロー解除の修正

### DIFF
--- a/custom/templates/user/meta/followers.tmpl
+++ b/custom/templates/user/meta/followers.tmpl
@@ -1,0 +1,6 @@
+{{template "base/head" .}}
+<div class="user followers">
+	{{template "user/meta/header" .}}
+	{{template "user/user_cards" .}}
+</div>
+{{template "base/footer" .}}

--- a/custom/templates/user/user_cards.tmpl
+++ b/custom/templates/user/user_cards.tmpl
@@ -23,8 +23,8 @@
 				{{if $.IsAdmin}}
 					<form class="display inline" action="{{$.RepoLink}}{{.HomeLink}}/action/unfollow?redirect_to={{$.Link}}" method="POST">
 						{{$.CSRFTokenHTML}}
-						<input type="hidden" name="user_id" value="{{.ID}}">
-						<button class="ui red small button">{{$.i18n.Tr "repo.unwatch"}}</button>
+						<!-- <input type="hidden" name="user_id" value="{{.ID}}"> -->
+						<button class="ui red small button">{{$.i18n.Tr "user.followers"}}</button>
 					</form>
 				{{end}}
 			</li>

--- a/custom/templates/user/user_cards.tmpl
+++ b/custom/templates/user/user_cards.tmpl
@@ -23,7 +23,6 @@
 				{{if $.IsAdmin}}
 					<form class="display inline" action="{{$.RepoLink}}{{.HomeLink}}/action/unfollow?redirect_to={{$.Link}}" method="POST">
 						{{$.CSRFTokenHTML}}
-						<!-- <input type="hidden" name="user_id" value="{{.ID}}"> -->
 						<button class="ui red small button">{{$.i18n.Tr "user.unfollow"}}</button>
 					</form>
 				{{end}}

--- a/custom/templates/user/user_cards.tmpl
+++ b/custom/templates/user/user_cards.tmpl
@@ -21,7 +21,7 @@
 				</div>
 
 				{{if $.IsAdmin}}
-					<form class="display inline" action="{{$.RepoLink}}/{{.HomeLink}}/action/unfollow?redirect_to={{$.Link}}" method="POST">
+					<form class="display inline" action="{{$.RepoLink}}{{.HomeLink}}/action/unfollow?redirect_to={{$.Link}}" method="POST">
 						{{$.CSRFTokenHTML}}
 						<input type="hidden" name="user_id" value="{{.ID}}">
 						<button class="ui red small button">{{$.i18n.Tr "repo.unwatch"}}</button>

--- a/custom/templates/user/user_cards.tmpl
+++ b/custom/templates/user/user_cards.tmpl
@@ -21,7 +21,7 @@
 				</div>
 
 				{{if $.IsAdmin}}
-					<form class="display inline" action="{{$.RepoLink}}/{{$.Name}}/action/unfollow?redirect_to={{$.Link}}" method="POST">
+					<form class="display inline" action="{{$.RepoLink}}/{{.HomeLink}}/action/unfollow?redirect_to={{$.Link}}" method="POST">
 						{{$.CSRFTokenHTML}}
 						<input type="hidden" name="user_id" value="{{.ID}}">
 						<button class="ui red small button">{{$.i18n.Tr "repo.unwatch"}}</button>

--- a/custom/templates/user/user_cards.tmpl
+++ b/custom/templates/user/user_cards.tmpl
@@ -24,7 +24,7 @@
 					<form class="display inline" action="{{$.RepoLink}}{{.HomeLink}}/action/unfollow?redirect_to={{$.Link}}" method="POST">
 						{{$.CSRFTokenHTML}}
 						<!-- <input type="hidden" name="user_id" value="{{.ID}}"> -->
-						<button class="ui red small button">{{$.i18n.Tr "user.followers"}}</button>
+						<button class="ui red small button">{{$.i18n.Tr "user.unfollow"}}</button>
 					</form>
 				{{end}}
 			</li>

--- a/custom/templates/user/user_cards.tmpl
+++ b/custom/templates/user/user_cards.tmpl
@@ -21,7 +21,7 @@
 				</div>
 
 				{{if $.IsAdmin}}
-					<form class="display inline" action="{{$.RepoLink}}/{{.Name}}/action/unfollow?redirect_to={{$.Link}}" method="POST">
+					<form class="display inline" action="{{$.RepoLink}}/{{$.Name}}/action/unfollow?redirect_to={{$.Link}}" method="POST">
 						{{$.CSRFTokenHTML}}
 						<input type="hidden" name="user_id" value="{{.ID}}">
 						<button class="ui red small button">{{$.i18n.Tr "repo.unwatch"}}</button>

--- a/custom/templates/user/user_cards.tmpl
+++ b/custom/templates/user/user_cards.tmpl
@@ -1,0 +1,55 @@
+<div class="ui container user-cards">
+	<h2 class="ui dividing header">
+		{{.CardsTitle}}
+	</h2>
+	<ul class="list">
+		{{range .Cards}}
+			<li class="item ui segment">
+				<a href="{{.HomeLink}}">
+					<img class="avatar" src="{{.RelAvatarLink}}"/>
+				</a>
+				<h3 class="name"><a href="{{.HomeLink}}">{{.DisplayName}}</a></h3>
+
+				<div class="meta">
+					{{if .Website}}
+						<span class="octicon octicon-link"></span> <a href="{{.Website}}" target="_blank" rel="noopener noreferrer">{{.Website}}</a>
+					{{else if .Location}}
+						<span class="octicon octicon-location"></span> {{.Location}}
+					{{else}}
+						<span class="octicon octicon-clock"></span> {{$.i18n.Tr "user.join_on"}} {{DateFmtShort .Created}}
+					{{end}}
+				</div>
+
+				{{if $.IsAdmin}}
+					<form class="display inline" action="{{$.RepoLink}}/action/unfollow?redirect_to={{$.Link}}" method="POST">
+						{{$.CSRFTokenHTML}}
+						<input type="hidden" name="user_id" value="{{.ID}}">
+						<button class="ui red small button">{{$.i18n.Tr "repo.unwatch"}}</button>
+					</form>
+				{{end}}
+			</li>
+		{{end}}
+	</ul>
+
+	{{with .Page}}
+		{{if gt .TotalPages 1}}
+			<div class="center page buttons">
+				<div class="ui borderless pagination menu">
+					<a class="{{if not .HasPrevious}}disabled{{end}} item" {{if .HasPrevious}}href="{{$.Link}}?page={{.Previous}}"{{end}}>
+						<i class="left arrow icon"></i> {{$.i18n.Tr "repo.issues.previous"}}
+					</a>
+					{{range .Pages}}
+						{{if eq .Num -1}}
+							<a class="disabled item">...</a>
+						{{else}}
+							<a class="{{if .IsCurrent}}active{{end}} item" {{if not .IsCurrent}}href="{{$.Link}}?page={{.Num}}"{{end}}>{{.Num}}</a>
+						{{end}}
+					{{end}}
+					<a class="{{if not .HasNext}}disabled{{end}} item" {{if .HasNext}}href="{{$.Link}}?page={{.Next}}"{{end}}>
+						{{$.i18n.Tr "repo.issues.next"}}&nbsp;<i class="icon right arrow"></i>
+					</a>
+				</div>
+			</div>
+		{{end}}
+	{{end}}
+</div>

--- a/custom/templates/user/user_cards.tmpl
+++ b/custom/templates/user/user_cards.tmpl
@@ -21,7 +21,7 @@
 				</div>
 
 				{{if $.IsAdmin}}
-					<form class="display inline" action="{{$.RepoLink}}/action/unfollow?redirect_to={{$.Link}}" method="POST">
+					<form class="display inline" action="{{$.RepoLink}}/{{.Name}}/action/unfollow?redirect_to={{$.Link}}" method="POST">
 						{{$.CSRFTokenHTML}}
 						<input type="hidden" name="user_id" value="{{.ID}}">
 						<button class="ui red small button">{{$.i18n.Tr "repo.unwatch"}}</button>

--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -655,7 +655,7 @@ func runWeb(c *cli.Context) error {
 			m.Get("", context.ServeGoGet(), repo.Home)
 			// Disable root of watch and star function by RCOS
 			// m.Get("/stars", repo.Stars)
-			// m.Get("/watchers", repo.Watchers)
+			m.Get("/watchers", repo.Watchers)
 		}, ignSignIn, context.RepoAssignment(), context.RepoRef())
 
 		// GIN specific code

--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -655,7 +655,7 @@ func runWeb(c *cli.Context) error {
 			m.Get("", context.ServeGoGet(), repo.Home)
 			// Disable root of watch and star function by RCOS
 			// m.Get("/stars", repo.Stars)
-			m.Get("/watchers", repo.Watchers)
+			// m.Get("/watchers", repo.Watchers)
 		}, ignSignIn, context.RepoAssignment(), context.RepoRef())
 
 		// GIN specific code

--- a/templates/user/user_cards.tmpl
+++ b/templates/user/user_cards.tmpl
@@ -1,0 +1,55 @@
+<div class="ui container user-cards">
+	<h2 class="ui dividing header">
+		{{.CardsTitle}}
+	</h2>
+	<ul class="list">
+		{{range .Cards}}
+			<li class="item ui segment">
+				<a href="{{.HomeLink}}">
+					<img class="avatar" src="{{.RelAvatarLink}}"/>
+				</a>
+				<h3 class="name"><a href="{{.HomeLink}}">{{.DisplayName}}</a></h3>
+
+				<div class="meta">
+					{{if .Website}}
+						<span class="octicon octicon-link"></span> <a href="{{.Website}}" target="_blank" rel="noopener noreferrer">{{.Website}}</a>
+					{{else if .Location}}
+						<span class="octicon octicon-location"></span> {{.Location}}
+					{{else}}
+						<span class="octicon octicon-clock"></span> {{$.i18n.Tr "user.join_on"}} {{DateFmtShort .Created}}
+					{{end}}
+				</div>
+
+				{{if $.IsAdmin}}
+					<form class="display inline" action="{{$.RepoLink}}/action/unwatch?redirect_to={{$.Link}}" method="POST">
+						{{$.CSRFTokenHTML}}
+						<input type="hidden" name="user_id" value="{{.ID}}">
+						<button class="ui red small button">{{$.i18n.Tr "repo.unwatch"}}</button>
+					</form>
+				{{end}}
+			</li>
+		{{end}}
+	</ul>
+
+	{{with .Page}}
+		{{if gt .TotalPages 1}}
+			<div class="center page buttons">
+				<div class="ui borderless pagination menu">
+					<a class="{{if not .HasPrevious}}disabled{{end}} item" {{if .HasPrevious}}href="{{$.Link}}?page={{.Previous}}"{{end}}>
+						<i class="left arrow icon"></i> {{$.i18n.Tr "repo.issues.previous"}}
+					</a>
+					{{range .Pages}}
+						{{if eq .Num -1}}
+							<a class="disabled item">...</a>
+						{{else}}
+							<a class="{{if .IsCurrent}}active{{end}} item" {{if not .IsCurrent}}href="{{$.Link}}?page={{.Num}}"{{end}}>{{.Num}}</a>
+						{{end}}
+					{{end}}
+					<a class="{{if not .HasNext}}disabled{{end}} item" {{if .HasNext}}href="{{$.Link}}?page={{.Next}}"{{end}}>
+						{{$.i18n.Tr "repo.issues.next"}}&nbsp;<i class="icon right arrow"></i>
+					</a>
+				</div>
+			</div>
+		{{end}}
+	{{end}}
+</div>


### PR DESCRIPTION
# PULL REQUEST

## Background

* ユーザフォロ一覧において、ユーザに対してWatch解除ボタンが設置されていた。
* 正しくはフォローを解除するボタンが正しい。
*  ユーザフォロ一覧においてフォローユーザの解除ができるように修正した。

## Main Points of Modification

*ユーザフォロ一覧画面において、フォロー中のユーザをフォロー解除できるように修正した。

## Test
LocalでGIN-forkをデプロイして、ユーザをフォロー解除できることを確認した。
