### PR TITLE
アドミン機能：一般ユーザのフォロー解除機能修正

### DIFF
--- a/custom/templates/user/meta/header.tmpl
+++ b/custom/templates/user/meta/header.tmpl
@@ -1,0 +1,10 @@
+{{with .Owner}}
+<div class="ui container">
+	<img class="ui avatar image" src="{{.RelAvatarLink}}">
+	<span class="header name">
+		<a href="{{.HomeLink}}">{{.Name}}</a>
+		{{with .FullName}}({{.}}){{end}}
+	</span>
+</div>
+{{end}}
+<div class="ui divider"></div>

--- a/custom/templates/user/user_cards.tmpl
+++ b/custom/templates/user/user_cards.tmpl
@@ -9,7 +9,6 @@
 					<img class="avatar" src="{{.RelAvatarLink}}"/>
 				</a>
 				<h3 class="name"><a href="{{.HomeLink}}">{{.DisplayName}}</a></h3>
-
 				<div class="meta">
 					{{if .Website}}
 						<span class="octicon octicon-link"></span> <a href="{{.Website}}" target="_blank" rel="noopener noreferrer">{{.Website}}</a>

--- a/custom/templates/user/user_cards.tmpl
+++ b/custom/templates/user/user_cards.tmpl
@@ -19,13 +19,6 @@
 						<span class="octicon octicon-clock"></span> {{$.i18n.Tr "user.join_on"}} {{DateFmtShort .Created}}
 					{{end}}
 				</div>
-
-				{{if $.IsAdmin}}
-					<form class="display inline" action="{{$.RepoLink}}{{.HomeLink}}/action/unfollow?redirect_to={{$.Link}}" method="POST">
-						{{$.CSRFTokenHTML}}
-						<button class="ui red small button">{{$.i18n.Tr "user.unfollow"}}</button>
-					</form>
-				{{end}}
 			</li>
 		{{end}}
 	</ul>


### PR DESCRIPTION
# PULL REQUEST

## Main Points of Modification

* 一般ユーザのフォロー解除ボタンを非表示にした。
* フォロー一覧の閲覧中のユーザに対するフォローボタンが不正であったため、削除した

## Test
LocalでGIN-forkのデプロイして修正反映を確認した。
