### PR TITLE
fix

### DIFF
--- a/custom/templates/repo/container.tmpl
+++ b/custom/templates/repo/container.tmpl
@@ -4,8 +4,9 @@
 	<div class="ui container">
         {{if .Repository}}
         <div class="twelve wide column content">
-            <h4 class="ui top attached header">{{.i18n.Tr "rcos.container.research"}}</h4>
-
+            <h4 class="ui top attached header">{{.i18n.Tr "rcos.container.research"}}
+                <a href="/{{.Repository.Owner.Name}}/{{.Repository.Name}}/launch/research" class="ui blue button" target="_blank" rel="noopener"> {{$.i18n.Tr "rcos.container.rebuild"}} </a>
+            </h4>
             <div class="ui unstackable attached table segment">
                 <table class="ui unstackable very basic striped table">
                     <thead>

--- a/custom/templates/repo/container.tmpl
+++ b/custom/templates/repo/container.tmpl
@@ -38,7 +38,9 @@
                 </table>
             </div>
             <h4 class="ui top attached header">{{.i18n.Tr "rcos.container.experiment"}}
+                {{if .HasExperiments}}
                 <a href="/{{.Repository.Owner.Name}}/{{.Repository.Name}}/launch/experiment" class="ui blue button" target="_blank" rel="noopener"> {{$.i18n.Tr "rcos.container.rebuild"}} </a>
+                {{end}}
             </h4>
             <div class="ui unstackable attached table segment">
                 <table class="ui unstackable very basic striped table">

--- a/custom/templates/repo/create.tmpl
+++ b/custom/templates/repo/create.tmpl
@@ -45,7 +45,7 @@
 								<input name="private" type="checkbox" checked readonly>
 								<label>{{.i18n.Tr "repo.visiblity_helper_forced" | Safe}}</label>
 							{{else}}
-								<input name="private" type="checkbox" {{if .private}}checked{{end}}>
+								<input name="private" type="checkbox" checked>
 								<label>{{.i18n.Tr "repo.visiblity_helper" | Safe}}</label>
 							{{end}}
 						</div>

--- a/custom/templates/repo/header.tmpl
+++ b/custom/templates/repo/header.tmpl
@@ -91,7 +91,7 @@ Commented out because it is not supported as a DG feature as of 2023/05/27. fork
 			{{end}}
 			{{if .IsRepositoryWriter}}
 			<a class="{{if .PageIsContainer}}active{{end}} item" href="{{.RepoLink}}/container">
-				{{.i18n.Tr "rcos.container.list"}}
+				<i class="i icon desktop"></i> {{.i18n.Tr "rcos.container.list"}}
 			</a>
 			{{end}}
 			{{if .IsRepositoryAdmin}}

--- a/internal/context/context_gin.go
+++ b/internal/context/context_gin.go
@@ -108,6 +108,17 @@ func hasFileInRepo(c AbstructContext, filePath string) bool {
 	return err == nil
 }
 
+func hasTreeInRepo(c AbstructContext, filePath string) bool {
+	commit, err := c.GetRepo().GetGitRepo().BranchCommit(c.GetRepo().GetDbRepo().GetDefaultBranch())
+	if err != nil {
+		log.Trace("Couldn't get commit: %v", err)
+		return false
+	}
+	_, err = commit.TreeEntry(filePath)
+
+	return err == nil
+}
+
 // True if repository is not Private, is not registered, or is registered and
 // has changes (HEAD is not registered)
 func isDOIReady(c *Context) bool {

--- a/internal/context/context_gin.go
+++ b/internal/context/context_gin.go
@@ -108,6 +108,9 @@ func hasFileInRepo(c AbstructContext, filePath string) bool {
 	return err == nil
 }
 
+// hasFileInRepo is RCOS specific code.
+// This probably returns 'true' if a repository includes a file or directory with the name given as an argument.
+// Used by context.RepoAssignment.
 func hasTreeInRepo(c AbstructContext, filePath string) bool {
 	commit, err := c.GetRepo().GetGitRepo().BranchCommit(c.GetRepo().GetDbRepo().GetDefaultBranch())
 	if err != nil {

--- a/internal/context/repo.go
+++ b/internal/context/repo.go
@@ -396,6 +396,7 @@ func RepoAssignment(pages ...bool) macaron.Handler {
 		}
 
 		c.Data["HasMaDmp"] = hasFileInRepo(c, "/maDMP.ipynb")
+		c.Data["HasExperiments"] = hasTreeInRepo(c, "/experiments")
 
 		// if doi := getRepoDOI(c); doi != "" && libgin.IsRegisteredDOI(doi) {
 		// 	c.Data["DOI"] = doi

--- a/internal/route/org/teams.go
+++ b/internal/route/org/teams.go
@@ -102,7 +102,13 @@ func TeamsAction(c *context.Context) {
 
 	switch page {
 	case "team":
-		c.Redirect(c.Org.OrgLink + "/teams/" + c.Org.Team.LowerName)
+		// avoid 404 error
+		if c.UserID() == uid && c.Params(":action") == "remove" {
+			c.Redirect("/" + c.Org.Organization.Name)
+		} else {
+			c.Redirect(c.Org.OrgLink + "/teams/" + c.Org.Team.LowerName)
+		}
+
 	default:
 		c.Redirect(c.Org.OrgLink + "/teams")
 	}


### PR DESCRIPTION
# PULL REQUEST

## Background

* プライベートリポジトリ対応

## Main Points of Modification

* 実行環境一覧の研究実行環境構築ボタン表示
* 実行環境一覧タブにマークの追加
* 組織で自分自身をチームから外したときに、組織のプロフィール画面へ遷移させる
* リポジトリ作成画面で非公開をデフォルトにする
* 実験の再構築ボタンを「experiments」ディレクトリのあるときのみ表示させる

## Test

- 研究実行環境の再構築ボタンが表示されていること
- 実行環境一覧タブの横にアイコンが表示されていること
- experimentsフォルダが存在する場合は実験実行環境再構築ボタンが表示され、フォルダが存在しない場合はボタンが表示されないこと

![スクリーンショット 2023-07-03 172927](https://github.com/NII-DG/gogs/assets/108637920/d7e73872-d045-49bc-99a1-ec25467bc262)

![スクリーンショット 2023-07-03 172859](https://github.com/NII-DG/gogs/assets/108637920/d16a1715-5014-47ab-8e4e-46e2a033ca24)

![スクリーンショット 2023-07-03 172937](https://github.com/NII-DG/gogs/assets/108637920/205c314f-16f8-4884-91ba-7b92c2d0cf7d)

![スクリーンショット 2023-07-03 172844](https://github.com/NII-DG/gogs/assets/108637920/47d12506-412b-4df7-8228-ae2261d3c6bd)