### PR TITLE
Feature/read only

### DIFF
--- a/custom/templates/repo/editor/edit.tmpl
+++ b/custom/templates/repo/editor/edit.tmpl
@@ -16,7 +16,7 @@
 						{{range $i, $v := .TreeNames}}
 							<div class="divider"> / </div>
 							{{if eq $i $l}}
-								{{if and (not $.CanEditFilePath) (not $.IsNewFile) }}
+								{{if or $.IsDmpJson (and (not $.CanEditFilePath) (not $.IsNewFile)) }}
 									<input id="file-name" value="{{$v}}" placeholder="{{$.i18n.Tr "repo.editor.name_your_file"}}" data-ec-url-prefix="{{$.EditorconfigURLPrefix}}" required autofocus readonly>
 								{{else}}
 									<input id="file-name" value="{{$v}}" placeholder="{{$.i18n.Tr "repo.editor.name_your_file"}}" data-ec-url-prefix="{{$.EditorconfigURLPrefix}}" required autofocus>

--- a/custom/templates/repo/editor/edit.tmpl
+++ b/custom/templates/repo/editor/edit.tmpl
@@ -16,7 +16,7 @@
 						{{range $i, $v := .TreeNames}}
 							<div class="divider"> / </div>
 							{{if eq $i $l}}
-								{{if $.IsDmpJson}}
+								{{if and (not $.CanEditFilePath) (not $.IsNewFile) }}
 									<input id="file-name" value="{{$v}}" placeholder="{{$.i18n.Tr "repo.editor.name_your_file"}}" data-ec-url-prefix="{{$.EditorconfigURLPrefix}}" required autofocus readonly>
 								{{else}}
 									<input id="file-name" value="{{$v}}" placeholder="{{$.i18n.Tr "repo.editor.name_your_file"}}" data-ec-url-prefix="{{$.EditorconfigURLPrefix}}" required autofocus>

--- a/internal/route/repo/editor.go
+++ b/internal/route/repo/editor.go
@@ -133,6 +133,7 @@ func editFile(c *context.Context, isNewFile bool) {
 	c.Data["PreviewableFileModes"] = strings.Join(conf.Repository.Editor.PreviewableFileModes, ",")
 	c.Data["EditorconfigURLPrefix"] = fmt.Sprintf("%s/api/v1/repos/%s/editorconfig/", conf.Server.Subpath, c.Repo.Repository.FullName())
 
+	_, c.Data["CanEditFilePath"] = canEditFile(c.Repo.TreePath)
 	c.Success(tmplEditorEdit)
 }
 

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	log "unknwon.dev/clog/v2"
@@ -549,4 +550,52 @@ func getWebContentURL(ctx *context.Context, key string) error {
 		ctx.Data["IsWebContent"] = true
 	}
 	return err
+}
+
+func canEditFile(filePath string) (canEditFile bool, canEditFilePath bool) {
+
+	canEditFile = true
+	canEditFilePath = true
+	cannotEditSet := make(map[string]bool)
+	cannotEditSet[".gitattributes"] = true
+	cannotEditSet[".gitignore"] = true
+	cannotEditSet[".repository_id"] = true
+	cannotEditSet["maDMP.ipynb"] = true
+	cannotEditSet[".datalad/.gitattributes"] = true
+	cannotEditSet[".datalad/config"] = true
+	cannotEditSet["validation_results/entity_ids.json"] = true
+	cannotEditSet["validation_results/results.json"] = true
+	cannotEditSet["validation_results/ro_crate.json"] = true
+	canEditSet := make(map[string]bool)
+	canEditSet["dmp.json"] = true
+	canEditSet["Dockerfile"] = true
+	canEditSet["README.md"] = true
+
+	if cannotEditSet[filePath] {
+		canEditFile = false
+		canEditFilePath = false
+		return canEditFile, canEditFilePath
+	}
+	if canEditSet[filePath] {
+		canEditFile = true
+		canEditFilePath = false
+		return canEditFile, canEditFilePath
+	}
+
+	re1 := regexp.MustCompile(`^experiments/.*?(environment\.yml|README\.md|requirements\.txt|Snakefile)$`)
+	if re1.MatchString(filePath) {
+		canEditFile = true
+		canEditFilePath = false
+		return canEditFile, canEditFilePath
+	}
+
+	re2 := regexp.MustCompile(`^experiments/.*?/\.gitkeep$`)
+	re3 := regexp.MustCompile(`^WORKFLOWS/.*?$`)
+	if re2.MatchString(filePath) || re3.MatchString(filePath) {
+		canEditFile = false
+		canEditFilePath = false
+		return canEditFile, canEditFilePath
+	}
+
+	return canEditFile, canEditFilePath
 }

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -552,6 +552,8 @@ func getWebContentURL(ctx *context.Context, key string) error {
 	return err
 }
 
+// canEditFile is RCOS specific code.
+// this returns whether file can be edited and file path can be edited.
 func canEditFile(filePath string) (canEditFile bool, canEditFilePath bool) {
 
 	canEditFile = true
@@ -582,14 +584,16 @@ func canEditFile(filePath string) (canEditFile bool, canEditFilePath bool) {
 		return canEditFile, canEditFilePath
 	}
 
-	re1 := regexp.MustCompile(`^experiments/.*?(environment\.yml|README\.md|requirements\.txt|Snakefile)$`)
+	// experiment/[実験パッケージ名]配下のenvironment.yml, README.md, requirement.txt, Snakefileにマッチ
+	re1 := regexp.MustCompile(`^experiments/.*?/(environment\.yml|README\.md|requirements\.txt|Snakefile)$`)
 	if re1.MatchString(filePath) {
 		canEditFile = true
 		canEditFilePath = false
 		return canEditFile, canEditFilePath
 	}
-
+	// experiment/[実験パッケージ名]配下の.gitkeepにマッチ
 	re2 := regexp.MustCompile(`^experiments/.*?/\.gitkeep$`)
+	// WORKFLOWS配下の全てにマッチ
 	re3 := regexp.MustCompile(`^WORKFLOWS/.*?$`)
 	if re2.MatchString(filePath) || re3.MatchString(filePath) {
 		canEditFile = false

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -591,8 +591,10 @@ func canEditFile(filePath string) (canEditFile bool, canEditFilePath bool) {
 		canEditFilePath = false
 		return canEditFile, canEditFilePath
 	}
+
 	// experiment/[実験パッケージ名]配下の.gitkeepにマッチ
 	re2 := regexp.MustCompile(`^experiments/.*?/\.gitkeep$`)
+
 	// WORKFLOWS配下の全てにマッチ
 	re3 := regexp.MustCompile(`^WORKFLOWS/.*?$`)
 	if re2.MatchString(filePath) || re3.MatchString(filePath) {

--- a/internal/route/repo/view.go
+++ b/internal/route/repo/view.go
@@ -294,6 +294,11 @@ func renderFile(c *context.Context, entry *git.TreeEntry, treeLink, rawLink stri
 	} else if !c.Repo.IsWriter() {
 		c.Data["DeleteFileTooltip"] = c.Tr("repo.editor.must_have_write_access")
 	}
+
+	// c.Data["CanDeleteFile"] = false
+	// c.Data["CanEditFile"] = false
+	// c.Data["CanEditFilePath"] = false
+
 }
 
 func setEditorconfigIfExists(c *context.Context) {

--- a/internal/route/repo/view.go
+++ b/internal/route/repo/view.go
@@ -295,10 +295,9 @@ func renderFile(c *context.Context, entry *git.TreeEntry, treeLink, rawLink stri
 		c.Data["DeleteFileTooltip"] = c.Tr("repo.editor.must_have_write_access")
 	}
 
-	// c.Data["CanDeleteFile"] = false
-	// c.Data["CanEditFile"] = false
-	// c.Data["CanEditFilePath"] = false
-
+	canEditFile, canEditFilePath := canEditFile(c.Repo.TreePath)
+	c.Data["CanEditFile"] = canEditFile
+	c.Data["CanDeleteFile"] = canEditFilePath
 }
 
 func setEditorconfigIfExists(c *context.Context) {


### PR DESCRIPTION
# PULL REQUEST

## Background

* ファイル編集時のファイル名のreadonly制御

## Main Points of Modification
- experiments配下のenvironment.yml, README.md, requirements.txt, Snakefileは内容のみ編集可能
- experiments配下の.gitkeepはファイル名含め編集不可
- WORKFLOWS配下のファイルは一括でファイル名含め編集不可
- リポジトリ直下のファイルは個別に判定する
- ファイル名編集不可の場合は横のinfoアイコンを表示させないようにする

## キャプチャ
- 編集不可のファイルは編集ボタン、削除ボタンともにグレーアウトする
![スクリーンショット 2023-07-04 164611](https://github.com/NII-DG/gogs/assets/108637920/cfdf3b80-034e-4c29-bf58-7588cb4e9ede)

- 内容のみ編集可能のファイルは編集ボタンを押すことができる
![スクリーンショット 2023-07-04 184104](https://github.com/NII-DG/gogs/assets/108637920/50c2f433-fdea-473b-a823-e0960f5044d0)
- 内容のみ編集可能のファイルのファイル名は変更不可で、infoアイコンが表示されない
![スクリーンショット 2023-07-04 184119](https://github.com/NII-DG/gogs/assets/108637920/42de446e-59ba-460d-bedf-d77f5b8f9eb6)














