### PR TITLE
ファイル削除時のダブルクリックの防止対応

### DIFF
--- a/custom/templates/repo/editor/delete.tmpl
+++ b/custom/templates/repo/editor/delete.tmpl
@@ -1,0 +1,12 @@
+{{template "base/head" .}}
+<div class="repository file editor delete">
+	{{template "repo/header" .}}
+	<div class="ui container">
+		{{template "base/alert" .}}
+		<form class="ui form" method="post" onSubmit="return PreventionDbClick();">
+			{{.CSRFTokenHTML}}
+			{{template "repo/editor/commit_form" .}}
+		</form>
+	</div>
+</div>
+{{template "base/footer" .}}

--- a/internal/route/repo/editor.go
+++ b/internal/route/repo/editor.go
@@ -345,6 +345,7 @@ func DiffPreviewPost(c *context.Context, f form.EditPreviewDiff) {
 }
 
 func DeleteFile(c *context.Context) {
+	log.Info("[DEBUG RCOS] ファイル削除処理開始")
 	c.PageIs("Delete")
 
 	entry, err := c.Repo.Commit.TreeEntry(c.Repo.TreePath)

--- a/internal/route/repo/editor.go
+++ b/internal/route/repo/editor.go
@@ -345,7 +345,7 @@ func DiffPreviewPost(c *context.Context, f form.EditPreviewDiff) {
 }
 
 func DeleteFile(c *context.Context) {
-	log.Info("[DEBUG RCOS] ファイル削除処理開始")
+	log.Info("[DEBUG RCOS] ファイル削除画面遷移")
 	c.PageIs("Delete")
 
 	entry, err := c.Repo.Commit.TreeEntry(c.Repo.TreePath)
@@ -369,6 +369,7 @@ func DeleteFile(c *context.Context) {
 }
 
 func DeleteFilePost(c *context.Context, f form.DeleteRepoFile) {
+	log.Info("[DEBUG RCOS] ファイル削除処理開始")
 	c.PageIs("Delete")
 	c.Data["BranchLink"] = c.Repo.RepoLink + "/src/" + c.Repo.BranchName
 

--- a/internal/route/repo/editor.go
+++ b/internal/route/repo/editor.go
@@ -345,7 +345,6 @@ func DiffPreviewPost(c *context.Context, f form.EditPreviewDiff) {
 }
 
 func DeleteFile(c *context.Context) {
-	log.Info("[DEBUG RCOS] ファイル削除画面遷移")
 	c.PageIs("Delete")
 
 	entry, err := c.Repo.Commit.TreeEntry(c.Repo.TreePath)
@@ -369,7 +368,6 @@ func DeleteFile(c *context.Context) {
 }
 
 func DeleteFilePost(c *context.Context, f form.DeleteRepoFile) {
-	log.Info("[DEBUG RCOS] ファイル削除処理開始")
 	c.PageIs("Delete")
 	c.Data["BranchLink"] = c.Repo.RepoLink + "/src/" + c.Repo.BranchName
 


### PR DESCRIPTION
# PULL REQUEST

## Background

* ファイル削除時の変更コミットボタンがダブルクリックできる。
* これにより、同じ処理が2回が走り、意図しないエラーメッセージが表示される。

## Main Points of Modification

* ファイル削除時のフォームにダブルクリック防止にJSメソッドを追加した。

## Test

* オンプレ環境でテストしてダブルクリックが禁止されていることを確認した。