### PR TITLE
fix commit link

### DIFF
--- a/internal/markup/markup.go
+++ b/internal/markup/markup.go
@@ -182,7 +182,8 @@ func RenderSpecialLink(rawBytes []byte, urlPrefix string, metas map[string]strin
 
 	rawBytes = RenderIssueIndexPattern(rawBytes, urlPrefix, metas)
 	rawBytes = RenderCrossReferenceIssueIndexPattern(rawBytes, urlPrefix, metas)
-	rawBytes = RenderSha1CurrentPattern(rawBytes, metas["repoLink"])
+	// avoid 404 link
+	// rawBytes = RenderSha1CurrentPattern(rawBytes, metas["repoLink"])
 	return rawBytes
 }
 


### PR DESCRIPTION
# PULL REQUEST

## Background

* Markdownファイルで半角英数字を8文字ほど連続して入力するとコミットリンクとして表示されるが、存在しないコミットへのリンクも生成される
* コミットリンクが10文字以上になると10文字に短縮されて表示される

## Main Points of Modification

* リンクを生成する部分を削除

## Test
* 修正前
![スクリーンショット 2023-07-18 134321](https://github.com/NII-DG/gogs/assets/108637920/49cae782-17ab-434c-97be-f3445ffccfd0)

* 修正後
![スクリーンショット 2023-07-18 134348](https://github.com/NII-DG/gogs/assets/108637920/5a332efb-d9b4-4f44-8551-1ba472fac0a6)

