### PR TITLE
fix panic

### DIFF
--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -689,6 +689,20 @@ func runWeb(c *cli.Context) error {
 		m.Group("/api", func() {
 			apiv1.RegisterRoutes(m)
 		}, ignSignIn)
+
+		// ***************************
+		// ----- HTTP Git routes -----
+		// ***************************
+
+		m.Group("/:username/:reponame", func() {
+			m.Get("/tasks/trigger", repo.TriggerTask)
+
+			m.Group("/info/lfs", func() {
+				lfs.RegisterRoutes(m.Router)
+			})
+
+			m.Route("/*", "GET,POST,OPTIONS", context.ServeGoGet(), repo.HTTPContexter(), repo.HTTP)
+		})
 	},
 		session.Sessioner(session.Options{
 			Provider:       conf.Session.Provider,
@@ -711,20 +725,6 @@ func runWeb(c *cli.Context) error {
 		}),
 		context.Contexter(),
 	)
-
-	// ***************************
-	// ----- HTTP Git routes -----
-	// ***************************
-
-	m.Group("/:username/:reponame", func() {
-		m.Get("/tasks/trigger", repo.TriggerTask)
-
-		m.Group("/info/lfs", func() {
-			lfs.RegisterRoutes(m.Router)
-		})
-
-		m.Route("/*", "GET,POST,OPTIONS", context.ServeGoGet(), repo.HTTPContexter(), repo.HTTP)
-	})
 
 	// ***************************
 	// ----- Internal routes -----

--- a/internal/route/repo/http.go
+++ b/internal/route/repo/http.go
@@ -100,6 +100,9 @@ func HTTPContexter() macaron.Handler {
 			!strings.Contains(action, "HEAD") &&
 			!strings.Contains(action, "objects/") {
 			c.NotFound()
+			c.Map(&HTTPContext{
+				Context: c,
+			})
 			return
 		}
 
@@ -434,5 +437,7 @@ func HTTP(c *HTTPContext) {
 		return
 	}
 
+	c.Data["Title"] = c.Tr("status.page_not_found")
+	c.HTML(http.StatusNotFound, fmt.Sprintf("status/%d", http.StatusNotFound))
 	c.NotFound()
 }


### PR DESCRIPTION
# PULL REQUEST

## Background

* プライベートリポジトリの場合、一部のURLでpanicが発生する

## Main Points of Modification

* panic回避のためHTTPContextを渡す処理を追加
* 404ページを表示する処理を追加
* context.Contexter()を呼んでcontextにログイン中のユーザーの情報を渡す処理を追加

## Test

* panicにならずに404ページが表示されること
![スクリーンショット 2023-07-18 152336](https://github.com/NII-DG/gogs/assets/108637920/abca1048-db9e-4758-9652-197468df18a1)
