### PR TITLE
Support for GIN button removal

### DIFF
--- a/custom/templates/repo/home.tmpl
+++ b/custom/templates/repo/home.tmpl
@@ -73,7 +73,8 @@
 				<!-- Only show clone panel in repository home page -->
 				{{if eq $n 0}}
 					<div class="ui action small input" id="clone-panel">
-						<button class="ui basic clone button" id="repo-clone-gin" data-link="{{.CloneLink.Gin}}">GIN</button>
+						<!-- Support for GIN button removal -->
+						<!-- <button class="ui basic clone button" id="repo-clone-gin" data-link="{{/*.CloneLink.Gin*/}}">GIN</button> -->
 						{{if not $.DisableHTTP}}
 							<button class="ui basic clone button" id="repo-clone-https" data-link="{{.CloneLink.HTTPS}}">
 								{{if UseHTTPS}}HTTPS{{else}}HTTP{{end}}

--- a/internal/db/repo.go
+++ b/internal/db/repo.go
@@ -709,7 +709,8 @@ type CloneLink struct {
 	SSH   string
 	HTTPS string
 	Git   string
-	Gin   string
+	// Support for GIN button removal
+	// Gin   string
 }
 
 // ComposeHTTPSCloneURL returns HTTPS clone URL based on given owner and repository name.
@@ -731,7 +732,8 @@ func (repo *Repository) cloneLink(isWiki bool) *CloneLink {
 		cl.SSH = fmt.Sprintf("%s@%s:/%s/%s.git", conf.App.RunUser, conf.SSH.Domain, repo.Owner.Name, repoName)
 	}
 	cl.HTTPS = ComposeHTTPSCloneURL(repo.Owner.Name, repoName)
-	cl.Gin = fmt.Sprintf("gin get %s/%s", repo.Owner.Name, repoName)
+	// Support for GIN button removal
+	// cl.Gin = fmt.Sprintf("gin get %s/%s", repo.Owner.Name, repoName)
 	return cl
 }
 


### PR DESCRIPTION
# PULL REQUEST

## Background

* GIN-forkでリポジトリのトップページ画面に記載されている、GINでpullするコマンドが間違えている。

## Main Points of Modification

* GINボタンを非表示にし、リンクが表示されないように修正する。

## Test

* 修正前
![before1](https://github.com/NII-DG/gogs/assets/138553905/cf03f768-db21-4533-b900-470e604417bf)

* 修正後
![after1](https://github.com/NII-DG/gogs/assets/138553905/7e52ba40-f51b-452e-9089-9e14b5c36eb0)
