### PR TITLE
fix filter mode

### DIFF
--- a/internal/route/user/home.go
+++ b/internal/route/user/home.go
@@ -234,10 +234,6 @@ func Issues(c *context.Context) {
 	for _, repo := range repos {
 		userRepoIDs = append(userRepoIDs, repo.ID)
 
-		if filterMode != db.FILTER_MODE_YOUR_REPOS {
-			continue
-		}
-
 		if isPullList {
 			if isShowClosed && repo.NumClosedPulls == 0 ||
 				!isShowClosed && repo.NumOpenPulls == 0 {


### PR DESCRIPTION
# PULL REQUEST

## Background

* 課題一覧の画面で、以下のような表示の違いがある
  * **あなたのリポジトリ** を選択するとリポジトリ名が表示される
  * **作成したリポジトリ** を選択するとリポジトリ名が表示され ない

## Main Points of Modification

* 課題一覧のフィルタで「あなたのリポジトリ」以外の場合にもリポジトリ名を表示するよう処理を変更

## Test

* **担当中のリポジトリ** の場合

  ![issues_assign_filter](https://github.com/NII-DG/gogs/assets/97083596/5cd7f480-3027-49ef-a3bd-0433b61c5d78)

* **作成したリポジトリ** の場合

  ![issues_created_by_filter](https://github.com/NII-DG/gogs/assets/97083596/6279e12e-2027-4b49-b556-73cf4a147321)