### PR TITLE
delete required items message on signup screen

### DIFF
--- a/custom/templates/user/auth/signup.tmpl
+++ b/custom/templates/user/auth/signup.tmpl
@@ -12,10 +12,13 @@
 					{{if .DisableRegistration}}
 						<p>{{.i18n.Tr "auth.disable_register_prompt"}}</p>
 					{{else}}
+					<!-- Support for deletion of required items message on signup screen -->
+					<!--
 					<div class="ui piled segment">
 						For Registration we require only username, password, and a valid email address, but adding your name and affiliation is recommended.
 						Please use an institutional email address for registration to benefit from the full set of features of GIN.
 					</div>
+					-->
 
 					<div class="ui divider"></div>
 


### PR DESCRIPTION
# PULL REQUEST

## Background

* ユーザー登録画面のガイダンスメッセージが実装と一致していない。

## Main Points of Modification

* ガイダンスメッセージを削除する対応を行う。

## Test

* 修正前
![image](https://github.com/NII-DG/gogs/assets/138553905/61e3782a-5b45-4fa9-937b-587e87bc69c6)

* 修正後
![image](https://github.com/NII-DG/gogs/assets/138553905/3e4fc8cf-a18a-4c11-bdd6-748a58bb8b3f)
