### PR TITLE
Feature/adjust menu and font

### DIFF
--- a/custom/public/css/rcos_custom/rcos_custom.css
+++ b/custom/public/css/rcos_custom/rcos_custom.css
@@ -39,6 +39,7 @@ This css is be adapted to template files in custom>templates
 /*----------------
     custom>templates>repo>home.tmpl
 ------------------*/
+@import url(http://fonts.googleapis.com/earlyaccess/notosansjp.css);
 #branch_item {
     background: transparent none!important;
     color: rgba(0,0,0,.6)!important;
@@ -49,7 +50,7 @@ This css is be adapted to template files in custom>templates
     -webkit-box-shadow: 0 0 0 1px rgba(34,36,38,.15) inset;
     box-shadow: 0 0 0 1px rgba(34,36,38,.15) inset;
     font-size: .92857143rem;
-    font-family: "Helvetica Neue",Arial,Helvetica,"Meiryo UI",sans-serif!important;
+    font-family: "Helvetica Neue",Arial,Helvetica,"Noto Sans JP",sans-serif!important;
     align-items: center;
     margin: auto 0.5em auto 0;
     padding: 0.78571429em 1.5em 0.78571429em;

--- a/custom/public/css/rcos_custom/rcos_custom.css
+++ b/custom/public/css/rcos_custom/rcos_custom.css
@@ -49,7 +49,7 @@ This css is be adapted to template files in custom>templates
     -webkit-box-shadow: 0 0 0 1px rgba(34,36,38,.15) inset;
     box-shadow: 0 0 0 1px rgba(34,36,38,.15) inset;
     font-size: .92857143rem;
-    font-family: "Helvetica Neue","Microsoft YaHei",Arial,Helvetica,sans-serif!important;
+    font-family: "Helvetica Neue","Meiryo UI",Arial,Helvetica,sans-serif!important;
     align-items: center;
     margin: auto 0.5em auto 0;
     padding: 0.78571429em 1.5em 0.78571429em;

--- a/custom/public/css/rcos_custom/rcos_custom.css
+++ b/custom/public/css/rcos_custom/rcos_custom.css
@@ -49,7 +49,7 @@ This css is be adapted to template files in custom>templates
     -webkit-box-shadow: 0 0 0 1px rgba(34,36,38,.15) inset;
     box-shadow: 0 0 0 1px rgba(34,36,38,.15) inset;
     font-size: .92857143rem;
-    font-family: "Helvetica Neue","Meiryo UI",Arial,Helvetica,sans-serif!important;
+    font-family: "Helvetica Neue",Arial,Helvetica,"Meiryo UI",sans-serif!important;
     align-items: center;
     margin: auto 0.5em auto 0;
     padding: 0.78571429em 1.5em 0.78571429em;

--- a/custom/public/css/rcos_custom/rcos_custom.css
+++ b/custom/public/css/rcos_custom/rcos_custom.css
@@ -70,6 +70,15 @@ This css is be adapted to template files in custom>templates
     white-space: normal;
 }
 
+select.dmp-menu {
+    text-align: left !important;
+}
+
+select.dmp-menu option:disabled {
+    color: #d95c5c;
+}
+
+
 /*----------------
     logout form
 ------------------*/

--- a/custom/templates/repo/header_gin.tmpl
+++ b/custom/templates/repo/header_gin.tmpl
@@ -22,7 +22,7 @@
 								{{else}}
 									{{if $.SchemaList}}
 									{{if $.IsRepositoryAdmin}}
-										<select class="ui basic button" name="addDmp" onChange="location.href=value;">
+										<select class="ui basic button dmp-menu" name="addDmp" onChange="location.href=value;">
 											<option value="" selected disabled>Add DMP</option>
 											{{ range $v := $.SchemaList }}
 												<option value="{{$.RepoLink}}/_add/{{EscapePound $.BranchName}}/dmp.json/?schema={{$v}}">{{ $v }}</option>

--- a/public/less/_base.less
+++ b/public/less/_base.less
@@ -1,7 +1,7 @@
 @footer-margin: 40px;
 
 body:not(.full-width) {
-  font-family: "Helvetica Neue", "Microsoft YaHei", Arial, Helvetica, sans-serif !important;
+  font-family: "Helvetica Neue", Arial, Helvetica, "Meiryo UI", sans-serif !important;
   background-color: #fff;
   overflow-y: scroll;
   overflow-x: auto;
@@ -19,7 +19,7 @@ h5,
 .ui.menu,
 .ui.input input,
 .ui.button:not(.label) {
-  font-family: "Helvetica Neue", "Microsoft YaHei", Arial, Helvetica, sans-serif !important;
+  font-family: "Helvetica Neue", Arial, Helvetica, "Meiryo UI", sans-serif !important;
 }
 img {
   border-radius: 3px;

--- a/public/less/_base.less
+++ b/public/less/_base.less
@@ -1,7 +1,9 @@
 @footer-margin: 40px;
+	
+@import url(http://fonts.googleapis.com/earlyaccess/notosansjp.css);
 
 body:not(.full-width) {
-  font-family: "Helvetica Neue", Arial, Helvetica, "Meiryo UI", sans-serif !important;
+  font-family: "Helvetica Neue", Arial, Helvetica, "Noto Sans JP", sans-serif !important;
   background-color: #fff;
   overflow-y: scroll;
   overflow-x: auto;
@@ -19,7 +21,7 @@ h5,
 .ui.menu,
 .ui.input input,
 .ui.button:not(.label) {
-  font-family: "Helvetica Neue", Arial, Helvetica, "Meiryo UI", sans-serif !important;
+  font-family: "Helvetica Neue", Arial, Helvetica, "Noto Sans JP", sans-serif !important;
 }
 img {
   border-radius: 3px;


### PR DESCRIPTION
# PULL REQUEST

## Background

* プルダウンの「Add DMP」の文字色変更
  * 目に入りやすくもなるし、選択肢との違いも明確になる。
  * プルダウンが中央揃えになっているが、見栄えがよくないので左揃えにする。 
* GINforkの日本語の字のフォントが変。
  * 簡体字になっている。

## Main Points of Modification

* プルダウンメニュー展開時に「Add DMP」だけ文字色を変更
  * CSSでスタイル設定して左揃えに
* GinforkでフォントにMicrosoft Yaheiを利用している箇所を、Noto Sans JPに変更

## Test

* プルダウンメニュー

  ![add_dmp_menu](https://github.com/NII-DG/gogs/assets/97083596/a7e33fdf-05eb-4e1c-823d-ac84caee8aa8)

* フォント
  * 変更前
     ![profile_before](https://github.com/NII-DG/gogs/assets/97083596/dfdfef90-f923-4eba-a649-cba63c220059)

  * 変更後
    ![profile_after](https://github.com/NII-DG/gogs/assets/97083596/74633e73-6116-42db-9454-83d565b9219b)