### PR TITLE
csrfのdomainを修正

### DIFF
--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -717,7 +717,6 @@ func runWeb(c *cli.Context) error {
 			Secret:         conf.Security.SecretKey,
 			Header:         "X-CSRF-Token",
 			Cookie:         conf.Session.CSRFCookieName,
-			CookieDomain:   conf.Server.URL.Hostname(),
 			CookiePath:     conf.Server.Subpath,
 			CookieHttpOnly: true,
 			SetCookie:      true,


### PR DESCRIPTION
# PULL REQUEST

## Background

*modify csrf domain #63の出し直し
*https://ivis.backlog.com/view/NII_DG-365の対応

## Main Points of Modification

* CokkieDomainの削除

## Test

*結合環境にて、Domainに"."がついていないことを確認。
![image](https://github.com/NII-DG/gogs/assets/81957555/9155d1e7-e979-4525-816a-db85cc1a3088)

【参考】
*本番環境だと"."がついている。
![image](https://github.com/NII-DG/gogs/assets/81957555/84f5ea08-4155-4c05-8106-10cafe06a9da)

## Viewpoint for Review

* 特になし

## Supplementary Information

* 本当にCSRFのエラーが発生しないかは、本番環境にリリース後でないと確認不可。
* 理屈としては、本対応で発生しなくなる想定。

## ToDo

* 本番環境リリース後の確認