### PR TITLE
fix readonly judge

### DIFF
--- a/internal/route/repo/view.go
+++ b/internal/route/repo/view.go
@@ -189,6 +189,7 @@ func renderFile(c *context.Context, entry *git.TreeEntry, treeLink, rawLink stri
 	}
 
 	canEnableEditor := c.Repo.CanEnableEditor()
+	canEditFile, canEditFilePath := canEditFile(c.Repo.TreePath)
 	switch {
 	case isTextFile:
 		// GIN mod: Use c.Data["FileSize"] which is replaced by annexed content
@@ -263,7 +264,7 @@ func renderFile(c *context.Context, entry *git.TreeEntry, treeLink, rawLink stri
 		}
 
 		isannex := tool.IsAnnexedFile(p)
-		if canEnableEditor && !isannex {
+		if canEnableEditor && !isannex && canEditFile {
 			c.Data["CanEditFile"] = true
 			c.Data["EditFileTooltip"] = c.Tr("repo.editor.edit_this_file")
 		} else if !c.Repo.IsViewBranch {
@@ -286,7 +287,7 @@ func renderFile(c *context.Context, entry *git.TreeEntry, treeLink, rawLink stri
 		c.Data["IsAnnexedFile"] = true
 	}
 
-	if canEnableEditor {
+	if canEnableEditor && canEditFilePath {
 		c.Data["CanDeleteFile"] = true
 		c.Data["DeleteFileTooltip"] = c.Tr("repo.editor.delete_this_file")
 	} else if !c.Repo.IsViewBranch {
@@ -294,10 +295,6 @@ func renderFile(c *context.Context, entry *git.TreeEntry, treeLink, rawLink stri
 	} else if !c.Repo.IsWriter() {
 		c.Data["DeleteFileTooltip"] = c.Tr("repo.editor.must_have_write_access")
 	}
-
-	canEditFile, canEditFilePath := canEditFile(c.Repo.TreePath)
-	c.Data["CanEditFile"] = canEditFile
-	c.Data["CanDeleteFile"] = canEditFilePath
 }
 
 func setEditorconfigIfExists(c *context.Context) {


### PR DESCRIPTION
# PULL REQUEST

## Background

過去のコミットの時点のファイルを閲覧時、編集削除ボタンが押せるようになってしまっている。
readonlyの判定を追加した際に、既存の編集削除可能判定を上書きしてしまったため。


## Main Points of Modification

* 既存の編集削除可能判定を上書きしないように修正

## Test

- 修正前
![スクリーンショット 2023-08-17 164251](https://github.com/NII-DG/gogs/assets/108637920/52417add-cc18-4cb1-b11a-47c9967bc649)
- 修正後
![スクリーンショット 2023-08-17 164311](https://github.com/NII-DG/gogs/assets/108637920/3e7a612c-fa2d-4ae2-99e9-0f8486c06698)
